### PR TITLE
Fix build breakage when PATH has directories with ' '

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ all: protos
 protos: ${PBS}
 
 %.pb: %.proto
-	PATH=~/bin:$(PATH):$(GOBIN) protoc -I networkservice $*.proto --go_out=plugins=grpc:go
+	PATH=~/bin:$${PATH}:$(GOBIN) protoc -I networkservice $*.proto --go_out=plugins=grpc:go


### PR DESCRIPTION
If the users PATH variable has ' ' in some directories,
then $(PATH) expands that in Make, which causes the shell
to interpret those spaces at the end of the PATH assignment
and the build breaks.  Buy switching to $${PATH} we cause
make to pass the ${PATH} to the shell which handles the expansion
correctly for the new path assignment.

Signed-off-by: Ed Warnicke <eaw@cisco.com>