### PR TITLE
Initialize channel as buffered

### DIFF
--- a/nsmdp/nsmdp.go
+++ b/nsmdp/nsmdp.go
@@ -36,6 +36,7 @@ func NewNSMDevicePlugin() *NSMDevicePlugin {
 		DevicePlugin: deviceplugin.NewDevicePlugin(serverSock, resourceName),
 		devs:         make(map[string]*NSMDevice),
 		stop:         make(chan interface{}),
+		updatedevs:   make(chan *NSMDevice, 10),
 	}
 	for i := uint(0); i < initDeviceCount; i++ {
 		dev := &NSMDevice{


### PR DESCRIPTION
If this channel is not buffered, the program hangs waiting
for something to read from it after we add the first item
into the channel.

Signed-off-by: Kyle Mestery <mestery@mestery.com>