### PR TITLE
Update to latest version of cn-infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -114,7 +114,7 @@
     "servicelabel",
     "utils/safeclose"
   ]
-  revision = "2d81f9bfd936b368e2843ac91b047816a51c0fb7"
+  revision = "2cfa6d8343bbb698758010828219b1c1f860c257"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -447,6 +447,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8fd62c146f80fd8da131e694bebf927200e427c661db8e65cfe63f8053fe0f8c"
+  inputs-digest = "09781e3692522656024cc6d52ebc5e0133a5b1b81832cbc6d7dfcaea13f6eb73"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -41,8 +41,7 @@ required = ["github.com/golang/protobuf/protoc-gen-go"]
 
 [[constraint]]
   name = "github.com/ligato/cn-infra"
-  revision = "2d81f9bfd936b368e2843ac91b047816a51c0fb7"
-#  revision = "6dc312561669efc1454463221f9f002e565e78d7"
+  revision = "2cfa6d8343bbb698758010828219b1c1f860c257"
 
 [[constraint]]
   name = "k8s.io/client-go"

--- a/vendor/github.com/ligato/cn-infra/core/event_loop.go
+++ b/vendor/github.com/ligato/cn-infra/core/event_loop.go
@@ -17,11 +17,12 @@ package core
 import (
 	"os"
 	"os/signal"
+	"syscall"
 )
 
 // EventLoopWithInterrupt starts an instance of the agent created with NewAgent().
-// Agent is stopped when <closeChan> is closed or a user interrupt (SIGINT)
-// is received.
+// Agent is stopped when <closeChan> is closed, a user interrupt (SIGINT), or a
+// terminate signal (SIGTERM) is received.
 func EventLoopWithInterrupt(agent *Agent, closeChan chan struct{}) error {
 	err := agent.Start()
 	if err != nil {
@@ -31,6 +32,7 @@ func EventLoopWithInterrupt(agent *Agent, closeChan chan struct{}) error {
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
+	signal.Notify(sigChan, syscall.SIGTERM)
 	select {
 	case <-sigChan:
 		agent.Println("Interrupt received, returning.")


### PR DESCRIPTION
This pulls in the following fix [1]. This allows EventLoopWithInterrupt to
handle SIGTERM, meaning when NSM is run as a daemonset it will handle
SIGTERM when the daemonset is deleted.

[1] https://github.com/ligato/cn-infra/pull/268

Signed-off-by: Kyle Mestery <mestery@mestery.com>