### PR TITLE
Fix creating a networkservice

### DIFF
--- a/conf/sample/networkservice.yaml
+++ b/conf/sample/networkservice.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   name: gold-network
   selector: routing
+  channels:
+    - name: 'gold-ethernet'

--- a/conf/sample/networkservice.yaml
+++ b/conf/sample/networkservice.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   name: gold-network
   selector: routing
-  channels: gold-ethernet


### PR DESCRIPTION
This fixes #66. We need to fix how we're creating channels as a part of
networkservice's in the yaml, because as it stands now, the errors
seen in #66 are a result of this not being setup correctly. This
addresses the issue by removing the channel from the sample yaml file.

Signed-off-by: Kyle Mestery <mestery@mestery.com>