### PR TITLE
Correctly handle deletions from queues

### DIFF
--- a/plugins/crd/crd_queue.go
+++ b/plugins/crd/crd_queue.go
@@ -74,7 +74,7 @@ func networkserviceWork(plugin *Plugin) {
 
 			if err != nil {
 				if queueNS.NumRequeues(key) < QUEUE_RETRY_COUNT {
-					plugin.Log.Errorf("Error processing item with key %s, error %v", key, err)
+					plugin.Log.Errorf("Requeueing after error processing item with key %s, error %v", key, err)
 					queueNS.AddRateLimited(key)
 					return
 				} else {
@@ -162,7 +162,7 @@ func networkservicechannelWork(plugin *Plugin) {
 
 			if err != nil {
 				if queueNSC.NumRequeues(key) < QUEUE_RETRY_COUNT {
-					plugin.Log.Errorf("Error processing item with key %s, error %v", key, err)
+					plugin.Log.Errorf("Requeueing after error processing item with key %s, error %v", key, err)
 					queueNSC.AddRateLimited(key)
 					return
 				} else {
@@ -250,7 +250,7 @@ func networkserviceendpointWork(plugin *Plugin) {
 
 			if err != nil {
 				if queueNSE.NumRequeues(key) < QUEUE_RETRY_COUNT {
-					plugin.Log.Errorf("Error processing item with key %s, error %v", key, err)
+					plugin.Log.Errorf("Requeueing after error processing item with key %s, error %v", key, err)
 					queueNSE.AddRateLimited(key)
 					return
 				} else {

--- a/plugins/crd/crd_queue.go
+++ b/plugins/crd/crd_queue.go
@@ -59,17 +59,9 @@ func networkserviceWork(plugin *Plugin) {
 			namespace, name, err := cache.SplitMetaNamespaceKey(strKey)
 
 			if err != nil {
-				// This is a soft-error, retry up to QUEUE_RETRY_COUNT times
+				// This is a soft-error
 				plugin.Log.Errorf("Error splitting meta namespace key into parts: %s", err.Error())
-				if err != nil {
-					if queueNS.NumRequeues(key) < QUEUE_RETRY_COUNT {
-						plugin.Log.Errorf("Error processing item with key %s, error %v", key, err)
-						queueNS.AddRateLimited(key)
-					} else {
-						plugin.Log.Errorf("Failed processing item with key %s, error %v, no more retries", key, err)
-						queueNS.Forget(key)
-					}
-				}
+				queueNS.Forget(key)
 				return
 			}
 
@@ -155,17 +147,9 @@ func networkservicechannelWork(plugin *Plugin) {
 			namespace, name, err := cache.SplitMetaNamespaceKey(strKey)
 
 			if err != nil {
-				// This is a soft-error, retry up to QUEUE_RETRY_COUNT times
+				// This is a soft-error
 				plugin.Log.Errorf("Error splitting meta namespace key into parts: %s", err.Error())
-				if err != nil {
-					if queueNSC.NumRequeues(key) < QUEUE_RETRY_COUNT {
-						plugin.Log.Errorf("Error processing item with key %s, error %v", key, err)
-						queueNSC.AddRateLimited(key)
-					} else {
-						plugin.Log.Errorf("Failed processing item with key %s, error %v, no more retries", key, err)
-						queueNSC.Forget(key)
-					}
-				}
+				queueNSC.Forget(key)
 				return
 			}
 
@@ -251,17 +235,9 @@ func networkserviceendpointWork(plugin *Plugin) {
 			namespace, name, err := cache.SplitMetaNamespaceKey(strKey)
 
 			if err != nil {
-				// This is a soft-error, retry up to QUEUE_RETRY_COUNT times
+				// This is a soft-error
 				plugin.Log.Errorf("Error splitting meta namespace key into parts: %s", err.Error())
-				if err != nil {
-					if queueNSE.NumRequeues(key) < QUEUE_RETRY_COUNT {
-						plugin.Log.Errorf("Error processing item with key %s, error %v", key, err)
-						queueNSE.AddRateLimited(key)
-					} else {
-						plugin.Log.Errorf("Failed processing item with key %s, error %v, no more retries", key, err)
-						queueNSE.Forget(key)
-					}
-				}
+				queueNSE.Forget(key)
 				return
 			}
 

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -68,6 +68,11 @@ type Plugin struct {
 	sharedFactoryNS  factory.SharedInformerFactory
 	sharedFactoryNSE factory.SharedInformerFactory
 	sharedFactoryNSC factory.SharedInformerFactory
+
+	// Informer factories per CRD object
+	informerNS  cache.SharedIndexInformer
+	informerNSE cache.SharedIndexInformer
+	informerNSC cache.SharedIndexInformer
 }
 
 var (
@@ -248,9 +253,9 @@ func informerNetworkServices(plugin *Plugin) {
 	// create/replace/update/delete operations are missed when watching
 	plugin.sharedFactoryNS = factory.NewSharedInformerFactory(plugin.crdClient, time.Second*30)
 
-	informer := plugin.sharedFactoryNS.Networkservice().V1().NetworkServices().Informer()
+	plugin.informerNS = plugin.sharedFactoryNS.Networkservice().V1().NetworkServices().Informer()
 	// We add a new event handler, watching for changes to API resources.
-	informer.AddEventHandler(
+	plugin.informerNS.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: networkserviceEnqueue,
 			UpdateFunc: func(old, cur interface{}) {
@@ -269,7 +274,7 @@ func informerNetworkServices(plugin *Plugin) {
 
 	// Wait for the informer cache to finish performing it's initial sync of
 	// resources
-	if !cache.WaitForCacheSync(plugin.stopChNS, informer.HasSynced) {
+	if !cache.WaitForCacheSync(plugin.stopChNS, plugin.informerNS.HasSynced) {
 		plugin.Log.Error("Error waiting for informer cache to sync")
 	}
 
@@ -286,9 +291,9 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 	// create/replace/update/delete operations are missed when watching
 	plugin.sharedFactoryNSC = factory.NewSharedInformerFactory(plugin.crdClient, time.Second*30)
 
-	informer := plugin.sharedFactoryNSC.Networkservice().V1().NetworkServiceChannels().Informer()
+	plugin.informerNSC = plugin.sharedFactoryNSC.Networkservice().V1().NetworkServiceChannels().Informer()
 	// we add a new event handler, watching for changes to API resources.
-	informer.AddEventHandler(
+	plugin.informerNSC.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: networkservicechannelEnqueue,
 			UpdateFunc: func(old, cur interface{}) {
@@ -307,7 +312,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 
 	// Wait for the informer cache to finish performing it's initial sync of
 	// resources
-	if !cache.WaitForCacheSync(plugin.stopChNSC, informer.HasSynced) {
+	if !cache.WaitForCacheSync(plugin.stopChNSC, plugin.informerNSC.HasSynced) {
 		plugin.Log.Errorf("Error waiting for informer cache to sync")
 	}
 
@@ -324,9 +329,9 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 	// create/replace/update/delete operations are missed when watching
 	plugin.sharedFactoryNSE = factory.NewSharedInformerFactory(plugin.crdClient, time.Second*30)
 
-	informer := plugin.sharedFactoryNSE.Networkservice().V1().NetworkServiceEndpoints().Informer()
+	plugin.informerNSE = plugin.sharedFactoryNSE.Networkservice().V1().NetworkServiceEndpoints().Informer()
 	// we add a new event handler, watching for changes to API resources.
-	informer.AddEventHandler(
+	plugin.informerNSE.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: networkserviceendpointEnqueue,
 			UpdateFunc: func(old, cur interface{}) {
@@ -345,7 +350,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 
 	// Wait for the informer cache to finish performing it's initial sync of
 	// resources
-	if !cache.WaitForCacheSync(plugin.stopChNSE, informer.HasSynced) {
+	if !cache.WaitForCacheSync(plugin.stopChNSE, plugin.informerNSE.HasSynced) {
 		plugin.Log.Errorf("Error waiting for informer cache to sync")
 	}
 


### PR DESCRIPTION
This commit closes #59.

This commit modifies how we process delete events from the queues.
Specifically, it does a few things:

* Saves off informers as a part of the CRD Plugin for use in queue
  processing.
* Uses GetByKey() to get an object instead of directly using the sharedfactory
  Lister function.
* GetByKey() allows us to determine if an item existed already, thus signaling
  a deletion.
* Retries SplitMetaNamespaceKey() and GetByKey() errors up to five times to
  handle transient errors.

With this change, the CRD code is now much more robust.

Signed-off-by: Kyle Mestery <mestery@mestery.com>