### PR TITLE
Add integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go_import_path: github.com/ligato/networkservicemesh
 script:
 - docker build -t ligato/networkservicemesh/netmesh-test -f build/nsm/docker/Test.Dockerfile .
 - docker build -t ligato/networkservicemesh/netmesh -f build/nsm/docker/Dockerfile .
+- ./scripts/integration-tests minikube
 
 notifications:
   irc:

--- a/scripts/cluster-up-dind.sh
+++ b/scripts/cluster-up-dind.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) 2016-2017 Bitnami
+# Copyright (c) 2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/cluster-up-dind.sh
+++ b/scripts/cluster-up-dind.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright (c) 2016-2017 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Bring up kubeadm-dind-cluster (docker-in-docker k8s cluster)
+DIND_CLUSTER_SH=dind-cluster-v1.7.sh
+DIND_URL=https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/${DIND_CLUSTER_SH}
+
+rm -f ${DIND_CLUSTER_SH}
+wget ${DIND_URL}
+chmod +x ${DIND_CLUSTER_SH}
+./${DIND_CLUSTER_SH} up
+# vim: sw=4 ts=4 et si

--- a/scripts/cluster-up-minikube.sh
+++ b/scripts/cluster-up-minikube.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) 2016-2017 Bitnami
+# Copyright (c) 2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/cluster-up-minikube.sh
+++ b/scripts/cluster-up-minikube.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Copyright (c) 2016-2017 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# From minikube howto
+export MINIKUBE_WANTUPDATENOTIFICATION=false
+export MINIKUBE_WANTREPORTERRORPROMPT=false
+export MINIKUBE_HOME=$HOME
+export CHANGE_MINIKUBE_NONE_USER=true
+mkdir -p ~/.kube
+touch ~/.kube/config
+
+export KUBECONFIG=$HOME/.kube/config
+export PATH=${PATH}:${GOPATH:?}/bin
+
+MINIKUBE_VERSION=v0.25.2
+
+install_bin() {
+    local exe=${1:?}
+    test -n "${TRAVIS}" && sudo install -v ${exe} /usr/local/bin || install ${exe} ${GOPATH:?}/bin
+}
+
+# Travis ubuntu trusty env doesn't have nsenter, needed for VM-less minikube
+# (--vm-driver=none, runs dockerized)
+check_or_build_nsenter() {
+    which nsenter >/dev/null && return 0
+    echo "INFO: Building 'nsenter' ..."
+cat <<-EOF | docker run -i --rm -v "$(pwd):/build" ubuntu:14.04 >& nsenter.build.log
+        apt-get update
+        apt-get install -qy git bison build-essential autopoint libtool automake autoconf gettext pkg-config
+        git clone --depth 1 git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git /tmp/util-linux
+        cd /tmp/util-linux
+        ./autogen.sh
+        ./configure --without-python --disable-all-programs --enable-nsenter
+        make nsenter
+        cp -pfv nsenter /build
+EOF
+    if [ ! -f ./nsenter ]; then
+        echo "ERROR: nsenter build failed, log:"
+        cat nsenter.build.log
+        return 1
+    fi
+    echo "INFO: nsenter build OK, installing ..."
+    install_bin ./nsenter
+}
+check_or_install_minikube() {
+    which minikube || {
+        wget --no-clobber -O minikube \
+            https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
+        install_bin ./minikube
+    }
+}
+
+# Install nsenter if missing
+check_or_build_nsenter
+# Install minikube if missing
+check_or_install_minikube
+MINIKUBE_BIN=$(which minikube)
+
+# Start minikube
+sudo -E ${MINIKUBE_BIN} start --vm-driver=none \
+    --extra-config=apiserver.Authorization.Mode=RBAC \
+    --kubernetes-version=v1.10.0
+
+# Wait til settles
+echo "INFO: Waiting for minikube cluster to be ready ..."
+typeset -i cnt=120
+until kubectl get pod --namespace=kube-system -lapp=kubernetes-dashboard|grep Running ; do
+    ((cnt=cnt-1)) || exit 1
+    sleep 1
+done
+exit 0
+# vim: sw=4 ts=4 et si

--- a/scripts/cluster-up-minikube.sh
+++ b/scripts/cluster-up-minikube.sh
@@ -26,6 +26,7 @@ export KUBECONFIG=$HOME/.kube/config
 export PATH=${PATH}:${GOPATH:?}/bin
 
 MINIKUBE_VERSION=v0.25.2
+KUBERNETES_VERSION=v1.10.0
 
 install_bin() {
     local exe=${1:?}
@@ -72,7 +73,7 @@ MINIKUBE_BIN=$(which minikube)
 # Start minikube
 sudo -E ${MINIKUBE_BIN} start --vm-driver=none \
     --extra-config=apiserver.Authorization.Mode=RBAC \
-    --kubernetes-version=v1.10.0
+    --kubernetes-version=${KUBERNETES_VERSION}
 
 # Wait til settles
 echo "INFO: Waiting for minikube cluster to be ready ..."

--- a/scripts/cluster_common.bash
+++ b/scripts/cluster_common.bash
@@ -1,0 +1,44 @@
+
+# Copyright (c) 2016-2017 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper functions to create / manage ephemeral minikube or dind cluster
+create_k8s_cluster() {
+    local ctx=${1:?}
+    # Start a k8s cluster (minikube, dind) if not running
+    kubectl api-versions --context=${ctx} >& /dev/null || {
+        cluster_up=./scripts/cluster-up-${ctx}.sh
+        test -f ${cluster_up} || {
+            echo "FATAL: bringing up k8s cluster '${ctx}' not supported"
+            exit 255
+        }
+        ${cluster_up}
+    }
+}
+fixup_rbac() {
+    local ctx=${1:?}
+    # As of ~Sept/2017 both RBAC'd dind and minikube seem to be missing rules to
+    # make kube-dns work properly add some (granted) broad ones:
+    kubectl --context=${ctx} get clusterrolebinding kube-dns-admin && return 0
+    kubectl --context=${ctx} create clusterrolebinding kube-dns-admin --serviceaccount=kube-system:default --clusterrole=cluster-admin
+}
+
+# Print ingress IP on stdout
+get_ingress_ip() {
+    local ctx=${1:?}
+    case ${ctx} in
+        minikube) minikube ip;;
+        dind)     kubectl get no kube-node-1 -ojsonpath='{.status.addresses[0].address}';;
+    esac
+}

--- a/scripts/cluster_common.bash
+++ b/scripts/cluster_common.bash
@@ -1,5 +1,6 @@
 
 # Copyright (c) 2016-2017 Bitnami
+# Copyright (c) 2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright (c) 2016-2017 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Default kubernetes context - if it's "dind" or "minikube" will
+# try to bring up a local (dockerized) cluster
+test -n "${TRAVIS_K8S_CONTEXT}" && set -- ${TRAVIS_K8S_CONTEXT}
+
+export TEST_CONTEXT=${1:?}
+
+KUBECTL_VERSION=v1.10.3
+
+# Install kubectl
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+	chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+
+# __main__ () {
+. scripts/cluster_common.bash
+
+# Create the 'minikube' or 'dind' cluster
+create_k8s_cluster ${TEST_CONTEXT}
+
+# Just exercising some kubectl-s
+KUBECTL_BIN=$(which kubectl)
+kubectl() {
+    ${KUBECTL_BIN:?} --context=${TEST_CONTEXT} "${@}"
+}
+
+(set -xe
+kubectl get nodes
+kubectl version
+kubectl api-versions
+kubectl label --overwrite --all=true nodes app=networkservice-node
+kubectl create -f conf/sample/networkservice-daemonset.yaml
+
+# Wait til settles
+echo "INFO: Waiting for Network Service Mesh daemonset to be up and CRDs to be available ..."
+typeset -i cnt=120
+until kubectl get crd | grep networkservicemesh.io ; do
+    ((cnt=cnt-1)) || exit 1
+    sleep 2
+done
+
+kubectl get nodes
+kubectl get pods
+kubectl get crd
+kubectl logs $(kubectl get pods -o name | sed -e 's/.*\///')
+
+kubectl create -f conf/sample/networkservice-channel.yaml
+kubectl create -f conf/sample/networkservice-endpoint.yaml
+kubectl create -f conf/sample/networkservice.yaml
+kubectl get pod,crd,NetworkServiceEndpoint,NetworkServiceChannel --all-namespaces
+)
+exit_code=$?
+[[ ${exit_code} == 0 ]] && echo "TESTS: PASS" || echo "TESTS: FAIL"
+exit ${exit_code}
+# }
+
+# vim: sw=4 ts=4 et si

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) 2016-2017 Bitnami
+# Copyright (c) 2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -40,6 +40,8 @@ kubectl() {
 }
 
 (set -xe
+# Remove the taint on the master node
+kubectl taint nodes --all node-role.kubernetes.io/master-
 kubectl get nodes
 kubectl version
 kubectl api-versions

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -62,7 +62,7 @@ kubectl logs $(kubectl get pods -o name | sed -e 's/.*\///')
 kubectl create -f conf/sample/networkservice-channel.yaml
 kubectl create -f conf/sample/networkservice-endpoint.yaml
 kubectl create -f conf/sample/networkservice.yaml
-kubectl get pod,crd,NetworkServiceEndpoint,NetworkServiceChannel --all-namespaces
+kubectl get pod,crd,NetworkService,NetworkServiceEndpoint,NetworkServiceChannel --all-namespaces
 )
 exit_code=$?
 [[ ${exit_code} == 0 ]] && echo "TESTS: PASS" || echo "TESTS: FAIL"

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -40,8 +40,6 @@ kubectl() {
 }
 
 (set -xe
-# Remove the taint on the master node
-kubectl taint nodes --all node-role.kubernetes.io/master-
 kubectl get nodes
 kubectl version
 kubectl api-versions


### PR DESCRIPTION
This will close issue #50.

This commit add some basic integration tests to verify that once the Docker
image is built we can create CRD resources in a minikube.

Signed-off-by: Kyle Mestery <mestery@mestery.com>