### PR TITLE
Adding unit tests for crd validation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -536,6 +536,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "41541a25027e7c4913c47ddede796e4d4e31a105f5a6cedf0509bea198fe9922"
+  inputs-digest = "e9e5cd83b431736687dc2bdf54b77893bcadde535917c6b56c4d029c20bb144c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -536,6 +536,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "59627edad6abacaffdacfa6b5bc2cecb7b2ad4d066382080817c6a0561cedcff"
+  inputs-digest = "41541a25027e7c4913c47ddede796e4d4e31a105f5a6cedf0509bea198fe9922"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -24,7 +24,6 @@ import (
 
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -118,7 +117,7 @@ func networkServiceValidation() *apiextv1beta1.CustomResourceValidation {
 							Type:        "string",
 							MaxLength:   &maxLength,
 							Description: "NetworkService Name",
-							Pattern:     `^[a-zA-Z0-9]+\-[a-zA-Z0-9]*$`,
+							Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
 						},
 						"uuid": apiextv1beta1.JSONSchemaProps{
 							Type:        "string",
@@ -147,7 +146,7 @@ func networkServiceEndpointsValidation() *apiextv1beta1.CustomResourceValidation
 							Type:        "string",
 							MaxLength:   &maxLength,
 							Description: "NetworkServiceEndpoints Name",
-							Pattern:     `^[a-zA-Z0-9]+\-[a-zA-Z0-9]*$`,
+							Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
 						},
 						"uuid": apiextv1beta1.JSONSchemaProps{
 							Type:        "string",
@@ -176,13 +175,13 @@ func networkServiceChannelsValidation() *apiextv1beta1.CustomResourceValidation 
 							Type:        "string",
 							MaxLength:   &maxLength,
 							Description: "NetworkServiceChannels Name",
-							Pattern:     `^[a-zA-Z0-9]+\-[a-zA-Z0-9]*$`,
+							Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
 						},
 						"payload": apiextv1beta1.JSONSchemaProps{
 							Type:        "string",
 							MaxLength:   &maxLength,
 							Description: "NetworkServiceChannels Payload",
-							Pattern:     `^[a-zA-Z0-9]+\-[a-zA-Z0-9]*$`,
+							Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
 						},
 					},
 				},
@@ -219,16 +218,7 @@ func createCRD(plugin *Plugin, FullName, Group, Version, Plural, Name string) er
 			Validation: validation,
 		},
 	}
-
 	_, cserr := plugin.apiclientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
-	if cserr != nil && apierrors.IsAlreadyExists(cserr) {
-		plugin.Log.Infof("Created CRD %s succesfully, though it already existed", Name)
-		return nil
-	} else if cserr != nil {
-		plugin.Log.Infof("Error creating CRD %s: %s", Name, cserr)
-	} else {
-		plugin.Log.Infof("Created CRD %s succesfully", Name)
-	}
 
 	return cserr
 }

--- a/plugins/crd/plugin_impl_crd_test.go
+++ b/plugins/crd/plugin_impl_crd_test.go
@@ -18,14 +18,17 @@ package netmeshplugincrd
 
 import (
 	"flag"
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/ligato/networkservicemesh/netmesh/model/netmesh"
 	"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1"
 	networkservicemesh "github.com/ligato/networkservicemesh/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -86,6 +89,19 @@ func setupEnv(k8s *kubernetes.Clientset, apiextClient *apiextcs.Clientset) error
 	if _, err := k8s.CoreV1().Namespaces().Create(&namespace); err != nil {
 		return err
 	}
+	// Need to wait until it appears
+	timeout := time.After(60 * time.Second)
+	tick := time.Tick(5 * time.Second)
+	_, err := k8s.CoreV1().Namespaces().Get(nsmTestNamespace, meta.GetOptions{})
+	for err != nil {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for %s namespace to be created", nsmTestNamespace)
+		case <-tick:
+			_, err = k8s.CoreV1().Namespaces().Get(nsmTestNamespace, meta.GetOptions{})
+		}
+	}
+
 	// Creating CRD definitions
 	for _, crd := range crds {
 		err := createCRD(&plugin, crd.fullname,
@@ -95,6 +111,18 @@ func setupEnv(k8s *kubernetes.Clientset, apiextClient *apiextcs.Clientset) error
 			crd.name)
 		if err != nil {
 			return err
+		}
+		// Need to wait until it appears
+		timeout := time.After(10 * time.Second)
+		tick := time.Tick(2 * time.Second)
+		_, err = apiextClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.fullname, meta.GetOptions{})
+		for err != nil {
+			select {
+			case <-timeout:
+				return fmt.Errorf("timeout waiting for %s crd to be created", crd.fullname)
+			case <-tick:
+				_, err = apiextClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.fullname, meta.GetOptions{})
+			}
 		}
 	}
 
@@ -113,14 +141,51 @@ func cleanupEnv(k8s *kubernetes.Clientset, apiextClient *apiextcs.Clientset) err
 		{name: reflect.TypeOf(v1.NetworkService{}).Name(), plural: v1.NSMPlural, fullname: v1.FullNSMName},
 	}
 	for _, crd := range crds {
-		err := apiextClient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(crd.fullname, &meta.DeleteOptions{})
-		if err != nil {
+		// Check if CRD already exists
+		_, err := apiextClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.fullname, meta.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// If not go to the next one
+			continue
+		}
+		// Need to clean it up
+		if err = apiextClient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(crd.fullname, &meta.DeleteOptions{}); err != nil {
 			return err
 		}
+		// Need to wait until it is really gone
+		timeout := time.After(10 * time.Second)
+		tick := time.Tick(2 * time.Second)
+		_, err = apiextClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.fullname, meta.GetOptions{})
+		for !apierrors.IsNotFound(err) {
+			select {
+			case <-timeout:
+				return fmt.Errorf("timeout waiting for %s crd to be deleted", crd.fullname)
+			case <-tick:
+				_, err = apiextClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.fullname, meta.GetOptions{})
+			}
+		}
+	}
+
+	_, err := k8s.CoreV1().Namespaces().Get(nsmTestNamespace, meta.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// If not, done
+		return nil
 	}
 	if err := k8s.CoreV1().Namespaces().Delete(nsmTestNamespace, &meta.DeleteOptions{}); err != nil {
 		return err
 	}
+	// Need to wait until it is really gone
+	timeout := time.After(60 * time.Second)
+	tick := time.Tick(5 * time.Second)
+	_, err = k8s.CoreV1().Namespaces().Get(nsmTestNamespace, meta.GetOptions{})
+	for !apierrors.IsNotFound(err) {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for %s namespace to be deleted", nsmTestNamespace)
+		case <-tick:
+			_, err = k8s.CoreV1().Namespaces().Get(nsmTestNamespace, meta.GetOptions{})
+		}
+	}
+
 	return nil
 }
 
@@ -131,7 +196,12 @@ func TestCRDValidation(t *testing.T) {
 	}
 	k8sClient, apiextClient, crdClient, err := k8sClient(kubeconfig)
 	if err != nil {
-		t.Errorf("Fail to get k8s client with error: %+v", err)
+		t.Skipf("Fail to get k8s client with error: %+v", err)
+	}
+	// Do unconditional cleanup of CRDs which could have been previously defined
+	err = cleanupEnv(k8sClient, apiextClient)
+	if err != nil {
+		t.Skipf("Fail to cleanup test environment before running tests with error: %+v", err)
 	}
 	if err := setupEnv(k8sClient, apiextClient); err != nil {
 		t.Errorf("Fail to setup test environment with error: %+v", err)

--- a/plugins/crd/plugin_impl_crd_test.go
+++ b/plugins/crd/plugin_impl_crd_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// //go:generate protoc -I ./model/pod --go_out=plugins=grpc:./model/pod ./model/pod/pod.proto
+
+package netmeshplugincrd
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+
+	"github.com/ligato/networkservicemesh/netmesh/model/netmesh"
+	"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1"
+	networkservicemesh "github.com/ligato/networkservicemesh/pkg/client/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	nsmTestNamespace = "networkservicemesh-test"
+)
+
+var kubeconfig string
+
+func init() {
+	kc := flag.String("kube-config", "", "Full path to k8s' cluster kubeconfig file.")
+	flag.Parse()
+	kubeconfig = *kc
+}
+
+func k8sClient(kc string) (*kubernetes.Clientset, *apiextcs.Clientset, *networkservicemesh.Clientset, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags("", kc)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	apiextClient, err := apiextcs.NewForConfig(cfg)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	crdClient, err := networkservicemesh.NewForConfig(cfg)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return kubeClient, apiextClient, crdClient, nil
+}
+
+func setupEnv(k8s *kubernetes.Clientset, apiextClient *apiextcs.Clientset) error {
+	crds := []struct {
+		name     string
+		plural   string
+		fullname string
+	}{
+		{name: reflect.TypeOf(v1.NetworkServiceEndpoint{}).Name(), plural: v1.NSMEPPlural, fullname: v1.FullNSMEPName},
+		{name: reflect.TypeOf(v1.NetworkServiceChannel{}).Name(), plural: v1.NSMChannelPlural, fullname: v1.FullNSMChannelName},
+		{name: reflect.TypeOf(v1.NetworkService{}).Name(), plural: v1.NSMPlural, fullname: v1.FullNSMName},
+	}
+	plugin := Plugin{
+		k8sClientset: k8s,
+		apiclientset: apiextClient,
+	}
+	// Setting up testing namespace
+	namespace := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsmTestNamespace,
+		},
+	}
+	if _, err := k8s.CoreV1().Namespaces().Create(&namespace); err != nil {
+		return err
+	}
+	// Creating CRD definitions
+	for _, crd := range crds {
+		err := createCRD(&plugin, crd.fullname,
+			v1.NSMGroup,
+			v1.NSMGroupVersion,
+			crd.plural,
+			crd.name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func cleanupEnv(k8s *kubernetes.Clientset, apiextClient *apiextcs.Clientset) error {
+
+	crds := []struct {
+		name     string
+		plural   string
+		fullname string
+	}{
+		{name: reflect.TypeOf(v1.NetworkServiceEndpoint{}).Name(), plural: v1.NSMEPPlural, fullname: v1.FullNSMEPName},
+		{name: reflect.TypeOf(v1.NetworkServiceChannel{}).Name(), plural: v1.NSMChannelPlural, fullname: v1.FullNSMChannelName},
+		{name: reflect.TypeOf(v1.NetworkService{}).Name(), plural: v1.NSMPlural, fullname: v1.FullNSMName},
+	}
+	for _, crd := range crds {
+		err := apiextClient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(crd.fullname, &metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	if err := k8s.CoreV1().Namespaces().Delete(nsmTestNamespace, &metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestCRDValidation(t *testing.T) {
+
+	if kubeconfig == "" {
+		t.Skip("This test requires a valid kubeconfig file, skipping...")
+	}
+	k8sClient, apiextClient, crdClient, err := k8sClient(kubeconfig)
+	if err != nil {
+		t.Errorf("Fail to get k8s client with error: %+v", err)
+	}
+	if err := setupEnv(k8sClient, apiextClient); err != nil {
+		t.Errorf("Fail to setup test environment with error: %+v", err)
+	}
+	defer func() {
+		if err := cleanupEnv(k8sClient, apiextClient); err != nil {
+			t.Errorf("Fail to cleanup test environment with error: %+v", err)
+		}
+	}()
+
+	testsNS := []struct {
+		testName   string
+		ns         v1.NetworkService
+		expectFail bool
+	}{
+		{
+			testName: "Network Service All Good",
+			ns: v1.NetworkService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nsm-service-1",
+					Namespace: nsmTestNamespace,
+				},
+				Spec: netmesh.NetworkService{
+					Name: "nsm-service-1",
+					Uuid: "81a66881-4052-46d3-9890-742da5a04b70",
+				},
+			},
+			expectFail: false,
+		},
+	}
+
+	for _, test := range testsNS {
+		_, err := crdClient.Networkservice().NetworkServices(nsmTestNamespace).Create(&test.ns)
+		if err != nil {
+			if !test.expectFail {
+				t.Errorf("Test '%s' is supposed to succeed but fail with error: %+v", test.testName, err)
+				continue
+			}
+		} else {
+			if test.expectFail {
+				t.Errorf("Test '%s' is supposed to fail but succeeded.", test.testName)
+				continue
+			}
+		}
+	}
+}

--- a/plugins/crd/plugin_impl_crd_test.go
+++ b/plugins/crd/plugin_impl_crd_test.go
@@ -161,6 +161,34 @@ func TestCRDValidation(t *testing.T) {
 			},
 			expectFail: false,
 		},
+		{
+			testName: "Network Service incorrect name",
+			ns: v1.NetworkService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nsm-serv%ice-1",
+					Namespace: nsmTestNamespace,
+				},
+				Spec: netmesh.NetworkService{
+					Name: "nsm-service-1",
+					Uuid: "81a66881-4052-46d3-9890-742da5a04b70",
+				},
+			},
+			expectFail: true,
+		},
+		{
+			testName: "Network Service incorrect UUID",
+			ns: v1.NetworkService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nsm-service-1",
+					Namespace: nsmTestNamespace,
+				},
+				Spec: netmesh.NetworkService{
+					Name: "nsm-service-1",
+					Uuid: "81a6688-4052-46d3-989-742da5a04b70",
+				},
+			},
+			expectFail: true,
+		},
 	}
 
 	for _, test := range testsNS {

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -66,7 +66,7 @@ kubectl create -f conf/sample/networkservice.yaml
 kubectl get pod,crd,NetworkService,NetworkServiceEndpoint,NetworkServiceChannel --all-namespaces
 
 # Need to get kubeconfig full path
-K8SCONFIG=$HOME'/.kube/config'
+K8SCONFIG=$HOME/.kube/config
 go test ./plugins/crd/... -v --kube-config=$K8SCONFIG
 )
 exit_code=$?

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -45,7 +45,6 @@ kubectl get nodes
 kubectl version
 kubectl api-versions
 kubectl label --overwrite --all=true nodes app=networkservice-node
-
 kubectl create -f conf/sample/networkservice-daemonset.yaml
 
 # Wait til settles
@@ -67,8 +66,8 @@ kubectl create -f conf/sample/networkservice.yaml
 kubectl get pod,crd,NetworkService,NetworkServiceEndpoint,NetworkServiceChannel --all-namespaces
 
 # Need to get kubeconfig full path
-k8sconfig=$HOME'/.kube/config'
-go test ./plugins/crd/... -v --kube-config=$k8sconfig
+K8SCONFIG=$HOME'/.kube/config'
+go test ./plugins/crd/... -v --kube-config=$K8SCONFIG
 )
 exit_code=$?
 [[ ${exit_code} == 0 ]] && echo "TESTS: PASS" || echo "TESTS: FAIL"

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -64,6 +64,9 @@ kubectl create -f conf/sample/networkservice-channel.yaml
 kubectl create -f conf/sample/networkservice-endpoint.yaml
 kubectl create -f conf/sample/networkservice.yaml
 kubectl get pod,crd,NetworkService,NetworkServiceEndpoint,NetworkServiceChannel --all-namespaces
+# Need to get kubeconfig full path
+k8sconfig=$(pwd $HOME)'/.kube/config'
+go test ./plugins/crd/... -v --kube-config=$k8sconfig
 )
 exit_code=$?
 [[ ${exit_code} == 0 ]] && echo "TESTS: PASS" || echo "TESTS: FAIL"

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -45,6 +45,7 @@ kubectl get nodes
 kubectl version
 kubectl api-versions
 kubectl label --overwrite --all=true nodes app=networkservice-node
+
 kubectl create -f conf/sample/networkservice-daemonset.yaml
 
 # Wait til settles
@@ -64,8 +65,9 @@ kubectl create -f conf/sample/networkservice-channel.yaml
 kubectl create -f conf/sample/networkservice-endpoint.yaml
 kubectl create -f conf/sample/networkservice.yaml
 kubectl get pod,crd,NetworkService,NetworkServiceEndpoint,NetworkServiceChannel --all-namespaces
+
 # Need to get kubeconfig full path
-k8sconfig=$(pwd $HOME)'/.kube/config'
+k8sconfig=$HOME'/.kube/config'
 go test ./plugins/crd/... -v --kube-config=$k8sconfig
 )
 exit_code=$?


### PR DESCRIPTION
This PR adds unit tests for CRD validation. Since the actual validation is done by the server, it must run against a live k8s cluster as a result `--kube-config` parameter must be passed to test:
Example: `go test -v --kube-config=/Users/sbezverk/.kube/config`

These tests are targeted for new CI environment, where a live k8s cluster gets build.
 
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>