### PR TITLE
Verify generated code during the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
 go_import_path: github.com/ligato/networkservicemesh
 
 script:
+- ./scripts/verify-codegen.sh
 - docker build -t ligato/networkservicemesh/netmesh-test -f build/nsm/docker/Test.Dockerfile .
 - docker build -t ligato/networkservicemesh/netmesh -f build/nsm/docker/Dockerfile .
 

--- a/scripts/verify-codegen.sh
+++ b/scripts/verify-codegen.sh
@@ -21,8 +21,8 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 SCRIPT_BASE=${SCRIPT_ROOT}/../..
 
-DIFFROOT="${SCRIPT_ROOT}/_examples"
-TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/_examples"
+DIFFROOT="${SCRIPT_ROOT}/pkg"
+TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/pkg"
 _tmp="${SCRIPT_ROOT}/_tmp"
 
 cleanup() {
@@ -49,5 +49,5 @@ else
 fi
 
 # smoke test
-echo "Smoke testing _example by compiling..."
-go build ${SCRIPT_ROOT}/_example/...
+echo "Smoke testing pkg by compiling..."
+go build ${SCRIPT_ROOT}/pkg/...


### PR DESCRIPTION
Closes #84

Run the verify-codegen.sh script to verify the generated code as a part
of the travis-ci runs.

Signed-off-by: Kyle Mestery <mestery@mestery.com>