### PR TITLE
Optimizing crd validation

### DIFF
--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -67,8 +67,8 @@ kubectl get pod,crd,NetworkService,NetworkServiceEndpoint,NetworkServiceChannel 
 
 # Need to get kubeconfig full path
 # NOTE: Disable this for now until we fix the timing issue
-#K8SCONFIG=$HOME/.kube/config
-#go test ./plugins/crd/... -v --kube-config=$K8SCONFIG
+K8SCONFIG=$HOME/.kube/config
+go test ./plugins/crd/... -v --kube-config=$K8SCONFIG
 )
 exit_code=$?
 [[ ${exit_code} == 0 ]] && echo "TESTS: PASS" || echo "TESTS: FAIL"


### PR DESCRIPTION
Since CRD objects are created as a separate task in CI, removing their creation from Validation Unit Tests.
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>