### PR TITLE
Fix informer factory usage

### DIFF
--- a/plugins/crd/crd_queue.go
+++ b/plugins/crd/crd_queue.go
@@ -41,7 +41,7 @@ var (
 // This file contains the work queue backends for each of the CRDs we create in the
 // plugin AfterInit() call.
 
-func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, stopCH chan struct{}) {
+func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer cache.SharedIndexInformer, stopCH chan struct{}) {
 	for {
 		// We read a message off the queue ...
 		key, shutdown := queue.Get()
@@ -82,7 +82,7 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, stopCH c
 			// Retrieve the latest version in the cache of this NetworkService. By using
 			// GetByKey() we are able to determine if the item exists, and thus if it was
 			// added or deleted from the queue, and process appropriately
-			item, exists, err := plugin.informerNS.GetIndexer().GetByKey(strKey)
+			item, exists, err := informer.GetIndexer().GetByKey(strKey)
 
 			if err != nil {
 				if queue.NumRequeues(key) < QueueRetryCount {

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -258,7 +258,7 @@ func informerNetworkServices(plugin *Plugin) {
 	plugin.Log.Info("NetworkService Informer is ready")
 
 	// Read forever from the work queue
-	workforever(plugin, queueNS, plugin.stopChNS)
+	workforever(plugin, queueNS, plugin.informerNS, plugin.stopChNS)
 }
 
 func informerNetworkServiceChannels(plugin *Plugin) {
@@ -296,7 +296,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 	plugin.Log.Info("NetworkServiceChannel Informer is ready")
 
 	// Read forever from the work queue
-	workforever(plugin, queueNSC, plugin.stopChNSC)
+	workforever(plugin, queueNSC, plugin.informerNSC, plugin.stopChNSC)
 }
 
 func informerNetworkServiceEndpoints(plugin *Plugin) {
@@ -334,7 +334,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 	plugin.Log.Info("NetworkServiceEndpoint Informer is ready")
 
 	// Read forever from the work queue
-	workforever(plugin, queueNSE, plugin.stopChNSE)
+	workforever(plugin, queueNSE, plugin.informerNSE, plugin.stopChNSE)
 }
 
 // AfterInit This will create all of the CRDs for NetworkServiceMesh.


### PR DESCRIPTION
Commit 060979e introduced a problem when refactoring the workqueue
code. It solely used the NetworkService informer, which meant that
we were not properly dequeueing NetworkServerChannels or
NetworkServiceEndpoints. This commit corrects this bug.

Signed-off-by: Kyle Mestery <mestery@mestery.com>