### PR TITLE
device plugin name fix

### DIFF
--- a/nsmdp/nsmdp.go
+++ b/nsmdp/nsmdp.go
@@ -23,9 +23,10 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"os"
+
 	"github.com/ligato/networkservicemesh/deviceplugin"
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
-	"os"
 )
 
 const (
@@ -45,7 +46,7 @@ type NSMDevice struct {
 }
 
 const (
-	resourceName    = "nsm.ligato.io"
+	resourceName    = "nsm.ligato.io/socket"
 	serverSock      = pluginapi.DevicePluginPath + "nsm.ligato.io.sock"
 	initDeviceCount = 10
 )


### PR DESCRIPTION
Closes: #100 

After this fix:
```
Jun 18 13:21:56 kube-5.sbezverk.cisco.com kubelet[1356]: I0618 13:21:56.639130    1356 manager.go:290] Got registration request from device plugin with resource name "nsm.ligato.io/socket"
Jun 18 13:21:56 kube-5.sbezverk.cisco.com kubelet[1356]: E0618 13:21:56.640441    1356 endpoint.go:132] listAndWatch ended unexpectedly for device plugin nsm.ligato.io/socket with error EOF

```
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>