### PR TITLE
Use a single shared informer for all CRDs

### DIFF
--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -58,13 +58,11 @@ type Plugin struct {
 	stopChNS  chan struct{}
 	stopChNSE chan struct{}
 	stopChNSC chan struct{}
-	// sharedFactory's are shared informer factorys used as a cache for
-	// items in the API server. They saves each informer listing and watch the
+	// sharedFactory is a shared informer factory used as a cache for
+	// items in the API server. It saves each informer listing and watches the
 	// same resources independently of each other, thus providing more up to
 	// date results with less 'effort'
-	sharedFactoryNS  factory.SharedInformerFactory
-	sharedFactoryNSE factory.SharedInformerFactory
-	sharedFactoryNSC factory.SharedInformerFactory
+	sharedFactory factory.SharedInformerFactory
 
 	// Informer factories per CRD object
 	informerNS  cache.SharedIndexInformer
@@ -228,13 +226,7 @@ func createCRD(plugin *Plugin, FullName, Group, Version, Plural, Name string) er
 }
 
 func informerNetworkServices(plugin *Plugin) {
-	// We use a shared informer from the informer factory, to save calls to the
-	// API as we grow our application and so state is consistent between our
-	// control loops. We set a resync period of 30 seconds, in case any
-	// create/replace/update/delete operations are missed when watching
-	plugin.sharedFactoryNS = factory.NewSharedInformerFactory(plugin.crdClient, time.Second*30)
-
-	plugin.informerNS = plugin.sharedFactoryNS.Networkservice().V1().NetworkServices().Informer()
+	plugin.informerNS = plugin.sharedFactory.Networkservice().V1().NetworkServices().Informer()
 	// We add a new event handler, watching for changes to API resources.
 	plugin.informerNS.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
@@ -247,32 +239,10 @@ func informerNetworkServices(plugin *Plugin) {
 			DeleteFunc: networkserviceEnqueue,
 		},
 	)
-
-	// Start the informer. This will cause it to begin receiving updates from
-	// the configured API server and firing event handlers in response.
-	plugin.sharedFactoryNS.Start(plugin.stopChNS)
-	plugin.Log.Info("Started NetworkService informer factory.")
-
-	// Wait for the informer cache to finish performing it's initial sync of
-	// resources
-	if !cache.WaitForCacheSync(plugin.stopChNS, plugin.informerNS.HasSynced) {
-		plugin.Log.Error("Error waiting for informer cache to sync")
-	}
-
-	plugin.Log.Info("NetworkService Informer is ready")
-
-	// Read forever from the work queue
-	workforever(plugin, queueNS, plugin.informerNS, plugin.stopChNS)
 }
 
 func informerNetworkServiceChannels(plugin *Plugin) {
-	// We use a shared informer from the informer factory, to save calls to the
-	// API as we grow our application and so state is consistent between our
-	// control loops. We set a resync period of 30 seconds, in case any
-	// create/replace/update/delete operations are missed when watching
-	plugin.sharedFactoryNSC = factory.NewSharedInformerFactory(plugin.crdClient, time.Second*30)
-
-	plugin.informerNSC = plugin.sharedFactoryNSC.Networkservice().V1().NetworkServiceChannels().Informer()
+	plugin.informerNSC = plugin.sharedFactory.Networkservice().V1().NetworkServiceChannels().Informer()
 	// we add a new event handler, watching for changes to API resources.
 	plugin.informerNSC.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
@@ -285,32 +255,10 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 			DeleteFunc: networkservicechannelEnqueue,
 		},
 	)
-
-	// Start the informer. This will cause it to begin receiving updates from
-	// the configured API server and firing event handlers in response.
-	plugin.sharedFactoryNSC.Start(plugin.stopChNSC)
-	plugin.Log.Info("Started NetworkServiceChannel informer factory.")
-
-	// Wait for the informer cache to finish performing it's initial sync of
-	// resources
-	if !cache.WaitForCacheSync(plugin.stopChNSC, plugin.informerNSC.HasSynced) {
-		plugin.Log.Errorf("Error waiting for informer cache to sync")
-	}
-
-	plugin.Log.Info("NetworkServiceChannel Informer is ready")
-
-	// Read forever from the work queue
-	workforever(plugin, queueNSC, plugin.informerNSC, plugin.stopChNSC)
 }
 
 func informerNetworkServiceEndpoints(plugin *Plugin) {
-	// We use a shared informer from the informer factory, to save calls to the
-	// API as we grow our application and so state is consistent between our
-	// control loops. We set a resync period of 30 seconds, in case any
-	// create/replace/update/delete operations are missed when watching
-	plugin.sharedFactoryNSE = factory.NewSharedInformerFactory(plugin.crdClient, time.Second*30)
-
-	plugin.informerNSE = plugin.sharedFactoryNSE.Networkservice().V1().NetworkServiceEndpoints().Informer()
+	plugin.informerNSE = plugin.sharedFactory.Networkservice().V1().NetworkServiceEndpoints().Informer()
 	// we add a new event handler, watching for changes to API resources.
 	plugin.informerNSE.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
@@ -323,22 +271,6 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 			DeleteFunc: networkserviceendpointEnqueue,
 		},
 	)
-
-	// Start the informer. This will cause it to begin receiving updates from
-	// the configured API server and firing event handlers in response.
-	plugin.sharedFactoryNSE.Start(plugin.stopChNSE)
-	plugin.Log.Info("Started NetworkServiceEndpoints informer factory.")
-
-	// Wait for the informer cache to finish performing it's initial sync of
-	// resources
-	if !cache.WaitForCacheSync(plugin.stopChNSE, plugin.informerNSE.HasSynced) {
-		plugin.Log.Errorf("Error waiting for informer cache to sync")
-	}
-
-	plugin.Log.Info("NetworkServiceEndpoint Informer is ready")
-
-	// Read forever from the work queue
-	workforever(plugin, queueNSE, plugin.informerNSE, plugin.stopChNSE)
 }
 
 // AfterInit This will create all of the CRDs for NetworkServiceMesh.
@@ -395,9 +327,33 @@ func (plugin *Plugin) AfterInit() error {
 		return err
 	}
 
-	go informerNetworkServices(plugin)
-	go informerNetworkServiceChannels(plugin)
-	go informerNetworkServiceEndpoints(plugin)
+	// We use a shared informer from the informer factory, to save calls to the
+	// API as we grow our application and so state is consistent between our
+	// control loops. We set a resync period of 30 seconds, in case any
+	// create/replace/update/delete operations are missed when watching
+	plugin.sharedFactory = factory.NewSharedInformerFactory(plugin.crdClient, time.Second*30)
+
+	informerNetworkServices(plugin)
+	informerNetworkServiceChannels(plugin)
+	informerNetworkServiceEndpoints(plugin)
+
+	// Start the informer. This will cause it to begin receiving updates from
+	// the configured API server and firing event handlers in response.
+	plugin.sharedFactory.Start(plugin.stopChNS)
+	plugin.Log.Info("Started NetworkService informer factory.")
+
+	// Wait for the informer cache to finish performing it's initial sync of
+	// resources
+	if !cache.WaitForCacheSync(plugin.stopChNS, plugin.informerNS.HasSynced) {
+		plugin.Log.Error("Error waiting for informer cache to sync")
+	}
+
+	plugin.Log.Info("NetworkService Informer is ready")
+
+	// Read forever from the work queue
+	go workforever(plugin, queueNS, plugin.informerNS, plugin.stopChNS)
+	go workforever(plugin, queueNSC, plugin.informerNSC, plugin.stopChNSC)
+	go workforever(plugin, queueNSE, plugin.informerNSE, plugin.stopChNSE)
 
 	return nil
 }


### PR DESCRIPTION
No need to use per-CRD informers when a single one works and makes
the code easier to read as a bonus.

Signed-off-by: Kyle Mestery <mestery@mestery.com>