### PR TITLE
Simplified wrapper around Logging

### DIFF
--- a/plugins/log/doc.go
+++ b/plugins/log/doc.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log

--- a/plugins/log/log_impl.go
+++ b/plugins/log/log_impl.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Simplified wrapper around github.com/ligato/cn-infra/logging that supports Sharing of Loggers
+package log
+
+import (
+	"github.com/ligato/cn-infra/logging"
+	"github.com/ligato/cn-infra/logging/logrus"
+	"sync"
+)
+
+// Unless told  otherwise, lets use a defaultRegistry
+var defaultLogRegistry = logrus.NewLogRegistry().(logging.LogFactory)
+
+// We have to track the Loggers because asking for a new one with the same name
+// will lead to a panic
+var logMap sync.Map
+
+// log simply implements the Logger interface by wrapping PluginLogger and adding Name()
+type log struct {
+	logging.PluginLogger
+}
+
+// Name returns the name of the plugin
+func (l *log) Name() string {
+	return l.GetName()
+}
+
+// SharedLog will retrieve a PluginLogger or create it if it doesn't exist
+// name - name for logger
+// parent - parent plugin if creating the log for a child Plugin
+//          if parent is not supplied, will use a defaultLogRegistry
+func SharedLog(name string, parent ...Logger) Logger {
+	logger := &log{}
+	n := name // need a copy of name in case we have to add a prefix to it
+	factory := defaultLogRegistry
+
+	if len(parent) > 0 {
+		factory = parent[0]
+		n = parent[0].GetName() + n // Have to compensate for use of parent as prefix
+	}
+
+	result, found := logMap.LoadOrStore(n, logger)
+	if found {
+		logger, _ = result.(*log)
+		return logger
+	}
+
+	logger.PluginLogger = logging.ForPlugin(name, factory)
+	return logger
+}

--- a/plugins/log/log_spi.go
+++ b/plugins/log/log_spi.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import "github.com/ligato/cn-infra/logging"
+
+// Logger provides the basic Logger for logging
+type Logger interface {
+	logging.PluginLogger
+	Name() string
+}

--- a/plugins/log/log_test.go
+++ b/plugins/log/log_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_test
+
+import (
+	"github.com/ligato/networkservicemesh/plugins/log"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+type Plugin struct {
+	log.Logger
+}
+
+func TestNewLog(t *testing.T) {
+	RegisterTestingT(t)
+	p1n := "p1"
+	l := log.SharedLog(p1n)
+	p1 := &Plugin{l}
+	Expect(l).ToNot(BeNil())
+	Expect(p1.Name()).To(Equal(p1n))
+
+	p2n := "p2"
+	l = log.SharedLog(p2n, p1)
+	p2 := &Plugin{l}
+	Expect(l).ToNot(BeNil())
+	Expect(p2.Name()).To(Equal(p1n + p2n))
+
+	l = log.SharedLog(p2n, p1)
+	Expect(l).To(Equal(p2.Logger))
+
+}


### PR DESCRIPTION
This package provides two things:

1)  log.SharedLogger(name,parent) that will provide you a SharedLogger
2)  An interface Logger that adds the Name() function so that if your
plugin name is the same as your logger, you don't have to carry around
the extra PluginName