### PR TITLE
Create and store events for CRD object operations

### DIFF
--- a/plugins/crd/crd_queue.go
+++ b/plugins/crd/crd_queue.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1"
 	"github.com/ligato/networkservicemesh/plugins/handler"
 )
 
@@ -97,14 +96,6 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer
 
 			// Verify if this was a delete vs. an add/update
 			if !exists {
-				switch item.(type) {
-				case v1.NetworkService:
-					plugin.Log.Info("FOUND NetworkService ITEM TYPE")
-				case v1.NetworkServiceChannel:
-					plugin.Log.Info("FOUND NetworkServiceChannel ITEM TYPE")
-				case v1.NetworkServiceEndpoint:
-					plugin.Log.Info("FOUND NetworkServiceEndpoint ITEM TYPE")
-				}
 				plugin.Log.Infof("Object (%s) deleted from queue", name)
 				plugin.HandlerAPI.ObjectDeleted(item, newEvent.(handler.NsmEvent))
 			} else {

--- a/plugins/crd/crd_queue.go
+++ b/plugins/crd/crd_queue.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
+	"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1"
 )
 
 // QueueRetryCount is the max number of times to retry processing a failed item
@@ -98,6 +100,14 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer
 
 			// Verify if this was a delete vs. an add/update
 			if !exists {
+				switch item.(type) {
+				case v1.NetworkService:
+					plugin.Log.Info("FOUND NetworkService ITEM TYPE")
+				case v1.NetworkServiceChannel:
+					plugin.Log.Info("FOUND NetworkServiceChannel ITEM TYPE")
+				case v1.NetworkServiceEndpoint:
+					plugin.Log.Info("FOUND NetworkServiceEndpoint ITEM TYPE")
+				}
 				plugin.Log.Infof("Object (%s) deleted from queue", name)
 				plugin.HandlerAPI.ObjectDeleted(item)
 			} else {

--- a/plugins/crd/crd_queue.go
+++ b/plugins/crd/crd_queue.go
@@ -59,7 +59,6 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer
 		// Convert the queue item into a string. If it's not a string, we'll
 		// simply discard it as invalid data and log a message.
 		var strKey string
-		var ok bool
 		strKey = newEvent.(handler.NsmEvent).KeyCur
 
 		// We define a function here to process a queue item, so that we can

--- a/plugins/crd/crd_queue.go
+++ b/plugins/crd/crd_queue.go
@@ -17,11 +17,9 @@
 package netmeshplugincrd
 
 import (
-	"fmt"
 	"reflect"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -105,6 +103,8 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer
 				return
 			}
 
+			plugin.Log.Infof("Found object of type: %T", reflect.TypeOf(message.(objectMessage).obj))
+
 			// Verify if this was a delete vs. an add/update
 			if !exists {
 				// If the object was deleted, it's no longer in the cache, so we'll use the copy
@@ -133,55 +133,4 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer
 			queue.Forget(message)
 		}(strKey)
 	}
-}
-
-// networkserviceEnqeue will add an object 'obj' into the workqueue. The object being added
-// must be of type metav1.Object, metav1.ObjectAccessor or cache.ExplicitKey.
-func networkserviceEnqueue(obj interface{}) {
-	// DeletionHandlingMetaNamespaceKeyFunc will convert an object into a
-	// 'namespace/name' string. We do this because our item may be processed
-	// much later than now, and so we want to ensure it gets a fresh copy of
-	// the resource when it starts. Also, this allows us to keep adding the
-	// same item into the work queue without duplicates building up.
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-	if err != nil {
-		runtime.HandleError(fmt.Errorf("error obtaining key for object being enqueue: %s", err.Error()))
-		return
-	}
-	// Add the item to the queue
-	queueNS.Add(key)
-}
-
-// networkserviceChannelEnqueue will add an object 'obj' into the workqueue. The object being added
-// must be of type metav1.Object, metav1.ObjectAccessor or cache.ExplicitKey.
-func networkservicechannelEnqueue(obj interface{}) {
-	// DeletionHandlingMetaNamespaceKeyFunc will convert an object into a
-	// 'namespace/name' string. We do this because our item may be processed
-	// much later than now, and so we want to ensure it gets a fresh copy of
-	// the resource when it starts. Also, this allows us to keep adding the
-	// same item into the work queue without duplicates building up.
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-	if err != nil {
-		runtime.HandleError(fmt.Errorf("error obtaining key for object being enqueue: %s", err.Error()))
-		return
-	}
-	// Add the item to the queue
-	queueNSC.Add(key)
-}
-
-// networkserviceEndpointEnqueue will add an object 'obj' into the workqueue. The object being added
-// must be of type metav1.Object, metav1.ObjectAccessor or cache.ExplicitKey.
-func networkserviceendpointEnqueue(obj interface{}) {
-	// DeletionHandlingMetaNamespaceKeyFunc will convert an object into a
-	// 'namespace/name' string. We do this because our item may be processed
-	// much later than now, and so we want to ensure it gets a fresh copy of
-	// the resource when it starts. Also, this allows us to keep adding the
-	// same item into the work queue without duplicates building up.
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-	if err != nil {
-		runtime.HandleError(fmt.Errorf("error obtaining key for object being enqueue: %s", err.Error()))
-		return
-	}
-	// Add the item to the queue
-	queueNSE.Add(key)
 }

--- a/plugins/crd/crd_queue.go
+++ b/plugins/crd/crd_queue.go
@@ -58,7 +58,7 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer
 		// Convert the queue item into a string. If it's not a string, we'll
 		// simply discard it as invalid data and log a message.
 		var strKey string
-		strKey = newEvent.(handler.NsmEvent).KeyCur
+		strKey = newEvent.(handler.NsmEvent).Key
 
 		// We define a function here to process a queue item, so that we can
 		// use 'defer' to make sure the message is marked as Done on the queue

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -266,7 +266,7 @@ func informerNetworkServices(plugin *Plugin) {
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				if reflect.DeepEqual(old, cur) {
+				if !reflect.DeepEqual(old, cur) {
 					// For an update event, we delete the old and add the current
 					var newEventOld, newEventCur handler.NsmEvent
 					var err error
@@ -336,7 +336,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				if reflect.DeepEqual(old, cur) {
+				if !reflect.DeepEqual(old, cur) {
 					// For an update event, we delete the old and add the current
 					var newEventOld, newEventCur handler.NsmEvent
 					var err error
@@ -406,7 +406,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				if reflect.DeepEqual(old, cur) {
+				if !reflect.DeepEqual(old, cur) {
 					// For an update event, we delete the old and add the current
 					var newEventOld, newEventCur handler.NsmEvent
 					var err error

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -248,42 +248,42 @@ func informerNetworkServices(plugin *Plugin) {
 	plugin.informerNS.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				var newEvent handler.NsmEvent
+				var message objectMessage
 				var err error
-				newEvent.Key, err = cache.MetaNamespaceKeyFunc(obj)
-				newEvent.EventType = handler.HandlerCreate
-				newEvent.ResourceType = handler.NetworkServiceResource
+				message.key, err = cache.MetaNamespaceKeyFunc(obj)
+				message.operation = create
+				message.obj = obj
 				if err == nil {
-					queueNS.Add(newEvent)
+					queueNS.Add(message)
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
 				if !reflect.DeepEqual(old, cur) {
 					// For an update event, we delete the old and add the current
-					var newEventOld, newEventCur handler.NsmEvent
+					var messageOld, messageCur objectMessage
 					var err error
-					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-					newEventOld.EventType = handler.HandlerDelete
-					newEventOld.ResourceType = handler.NetworkServiceResource
+					messageOld.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+					messageOld.operation = delete
+					messageOld.obj = old
 					if err == nil {
-						queueNS.Add(newEventOld)
+						queueNS.Add(messageOld)
 					}
-					newEventCur.Key, err = cache.MetaNamespaceKeyFunc(cur)
-					newEventCur.EventType = handler.HandlerCreate
-					newEventCur.ResourceType = handler.NetworkServiceResource
+					messageCur.key, err = cache.MetaNamespaceKeyFunc(cur)
+					messageCur.operation = create
+					messageCur.obj = cur
 					if err == nil {
-						queueNS.Add(newEventCur)
+						queueNS.Add(messageCur)
 					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				var newEvent handler.NsmEvent
+				var message objectMessage
 				var err error
-				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				newEvent.EventType = handler.HandlerDelete
-				newEvent.ResourceType = handler.NetworkServiceResource
+				message.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				message.operation = delete
+				message.obj = obj
 				if err == nil {
-					queueNS.Add(newEvent)
+					queueNS.Add(message)
 				}
 			},
 		},
@@ -296,42 +296,42 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 	plugin.informerNSC.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				var newEvent handler.NsmEvent
+				var message objectMessage
 				var err error
-				newEvent.Key, err = cache.MetaNamespaceKeyFunc(obj)
-				newEvent.EventType = handler.HandlerCreate
-				newEvent.ResourceType = handler.NetworkServiceChannelResource
+				message.key, err = cache.MetaNamespaceKeyFunc(obj)
+				message.operation = create
+				message.obj = obj
 				if err == nil {
-					queueNSC.Add(newEvent)
+					queueNSC.Add(message)
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
 				if !reflect.DeepEqual(old, cur) {
 					// For an update event, we delete the old and add the current
-					var newEventOld, newEventCur handler.NsmEvent
+					var messageOld, messageCur objectMessage
 					var err error
-					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-					newEventOld.EventType = handler.HandlerDelete
-					newEventOld.ResourceType = handler.NetworkServiceChannelResource
+					messageOld.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+					messageOld.operation = delete
+					messageOld.obj = old
 					if err == nil {
-						queueNSC.Add(newEventOld)
+						queueNSC.Add(messageOld)
 					}
-					newEventCur.Key, err = cache.MetaNamespaceKeyFunc(cur)
-					newEventCur.EventType = handler.HandlerCreate
-					newEventCur.ResourceType = handler.NetworkServiceChannelResource
+					messageCur.key, err = cache.MetaNamespaceKeyFunc(cur)
+					messageCur.operation = create
+					messageCur.obj = cur
 					if err == nil {
-						queueNSC.Add(newEventCur)
+						queueNSC.Add(messageCur)
 					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				var newEvent handler.NsmEvent
+				var message objectMessage
 				var err error
-				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				newEvent.EventType = handler.HandlerDelete
-				newEvent.ResourceType = handler.NetworkServiceChannelResource
+				message.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				message.operation = delete
+				message.obj = obj
 				if err == nil {
-					queueNSC.Add(newEvent)
+					queueNSC.Add(message)
 				}
 			},
 		},
@@ -344,42 +344,42 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 	plugin.informerNSE.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				var newEvent handler.NsmEvent
+				var message objectMessage
 				var err error
-				newEvent.Key, err = cache.MetaNamespaceKeyFunc(obj)
-				newEvent.EventType = handler.HandlerCreate
-				newEvent.ResourceType = handler.NetworkServiceEndpointResource
+				message.key, err = cache.MetaNamespaceKeyFunc(obj)
+				message.operation = create
+				message.obj = obj
 				if err == nil {
-					queueNSE.Add(newEvent)
+					queueNSE.Add(message)
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
 				if !reflect.DeepEqual(old, cur) {
 					// For an update event, we delete the old and add the current
-					var newEventOld, newEventCur handler.NsmEvent
+					var messageOld, messageCur objectMessage
 					var err error
-					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-					newEventOld.EventType = handler.HandlerDelete
-					newEventOld.ResourceType = handler.NetworkServiceEndpointResource
+					messageOld.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+					messageOld.operation = delete
+					messageOld.obj = old
 					if err == nil {
-						queueNSE.Add(newEventOld)
+						queueNSE.Add(messageOld)
 					}
-					newEventCur.Key, err = cache.MetaNamespaceKeyFunc(cur)
-					newEventCur.EventType = handler.HandlerCreate
-					newEventCur.ResourceType = handler.NetworkServiceEndpointResource
+					messageCur.key, err = cache.MetaNamespaceKeyFunc(cur)
+					messageCur.operation = create
+					messageCur.obj = cur
 					if err == nil {
-						queueNSE.Add(newEventCur)
+						queueNSE.Add(messageCur)
 					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				var newEvent handler.NsmEvent
+				var message objectMessage
 				var err error
-				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				newEvent.EventType = handler.HandlerDelete
-				newEvent.ResourceType = handler.NetworkServiceEndpointResource
+				message.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				message.operation = delete
+				message.obj = obj
 				if err == nil {
-					queueNSE.Add(newEvent)
+					queueNSE.Add(message)
 				}
 			},
 		},

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -252,7 +252,7 @@ func informerNetworkServices(plugin *Plugin) {
 				var err error
 				newEvent.Key, err = cache.MetaNamespaceKeyFunc(obj)
 				newEvent.EventType = handler.HandlerCreate
-				newEvent.ResourceType = obj.(v1.NetworkService)
+				newEvent.ResourceType = handler.NetworkServiceResource
 				if err == nil {
 					queueNS.Add(newEvent)
 				}
@@ -264,13 +264,13 @@ func informerNetworkServices(plugin *Plugin) {
 					var err error
 					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
 					newEventOld.EventType = handler.HandlerDelete
-					newEventOld.ResourceType = old.(v1.NetworkService)
+					newEventOld.ResourceType = handler.NetworkServiceResource
 					if err == nil {
 						queueNS.Add(newEventOld)
 					}
 					newEventCur.Key, err = cache.MetaNamespaceKeyFunc(cur)
 					newEventCur.EventType = handler.HandlerCreate
-					newEventCur.ResourceType = cur.(v1.NetworkService)
+					newEventCur.ResourceType = handler.NetworkServiceResource
 					if err == nil {
 						queueNS.Add(newEventCur)
 					}
@@ -281,7 +281,7 @@ func informerNetworkServices(plugin *Plugin) {
 				var err error
 				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				newEvent.EventType = handler.HandlerDelete
-				newEvent.ResourceType = obj.(v1.NetworkService)
+				newEvent.ResourceType = handler.NetworkServiceResource
 				if err == nil {
 					queueNS.Add(newEvent)
 				}
@@ -300,7 +300,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 				var err error
 				newEvent.Key, err = cache.MetaNamespaceKeyFunc(obj)
 				newEvent.EventType = handler.HandlerCreate
-				newEvent.ResourceType = obj.(v1.NetworkServiceChannel)
+				newEvent.ResourceType = handler.NetworkServiceChannelResource
 				if err == nil {
 					queueNSC.Add(newEvent)
 				}
@@ -312,13 +312,13 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 					var err error
 					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
 					newEventOld.EventType = handler.HandlerDelete
-					newEventOld.ResourceType = old.(v1.NetworkServiceChannel)
+					newEventOld.ResourceType = handler.NetworkServiceChannelResource
 					if err == nil {
 						queueNSC.Add(newEventOld)
 					}
 					newEventCur.Key, err = cache.MetaNamespaceKeyFunc(cur)
 					newEventCur.EventType = handler.HandlerCreate
-					newEventCur.ResourceType = cur.(v1.NetworkServiceChannel)
+					newEventCur.ResourceType = handler.NetworkServiceChannelResource
 					if err == nil {
 						queueNSC.Add(newEventCur)
 					}
@@ -329,7 +329,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 				var err error
 				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				newEvent.EventType = handler.HandlerDelete
-				newEvent.ResourceType = obj.(v1.NetworkServiceChannel)
+				newEvent.ResourceType = handler.NetworkServiceChannelResource
 				if err == nil {
 					queueNSC.Add(newEvent)
 				}
@@ -348,7 +348,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 				var err error
 				newEvent.Key, err = cache.MetaNamespaceKeyFunc(obj)
 				newEvent.EventType = handler.HandlerCreate
-				newEvent.ResourceType = obj.(v1.NetworkServiceEndpoint)
+				newEvent.ResourceType = handler.NetworkServiceEndpointResource
 				if err == nil {
 					queueNSE.Add(newEvent)
 				}
@@ -360,13 +360,13 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 					var err error
 					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
 					newEventOld.EventType = handler.HandlerDelete
-					newEventOld.ResourceType = old.(v1.NetworkServiceEndpoint)
+					newEventOld.ResourceType = handler.NetworkServiceEndpointResource
 					if err == nil {
 						queueNSE.Add(newEventOld)
 					}
 					newEventCur.Key, err = cache.MetaNamespaceKeyFunc(cur)
 					newEventCur.EventType = handler.HandlerCreate
-					newEventCur.ResourceType = cur.(v1.NetworkServiceEndpoint)
+					newEventCur.ResourceType = handler.NetworkServiceEndpointResource
 					if err == nil {
 						queueNSE.Add(newEventCur)
 					}
@@ -377,7 +377,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 				var err error
 				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				newEvent.EventType = handler.HandlerDelete
-				newEvent.ResourceType = obj.(v1.NetworkServiceEndpoint)
+				newEvent.ResourceType = handler.NetworkServiceEndpointResource
 				if err == nil {
 					queueNSE.Add(newEvent)
 				}

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -258,7 +258,7 @@ func informerNetworkServices(plugin *Plugin) {
 			AddFunc: func(obj interface{}) {
 				var newEvent handler.NsmEvent
 				var err error
-				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				newEvent.EventType = "create"
 				newEvent.ResourceType = handler.NetworkServiceResource
 				if err == nil {
@@ -266,20 +266,26 @@ func informerNetworkServices(plugin *Plugin) {
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				var newEvent handler.NsmEvent
-				var err1, err2 error
-				newEvent.KeyOld, err2 = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-				newEvent.KeyCur, err1 = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
-				newEvent.EventType = "update"
-				newEvent.ResourceType = handler.NetworkServiceResource
-				if err1 == nil && err2 == nil {
-					queueNS.Add(newEvent)
+				// For an update event, we delete the old and add the current
+				var newEventOld, newEventCur handler.NsmEvent
+				var err error
+				newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+				newEventOld.EventType = "delete"
+				newEventOld.ResourceType = handler.NetworkServiceResource
+				if err == nil {
+					queueNS.Add(newEventOld)
+				}
+				newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
+				newEventCur.EventType = "create"
+				newEventCur.ResourceType = handler.NetworkServiceResource
+				if err == nil {
+					queueNS.Add(newEventCur)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				var newEvent handler.NsmEvent
 				var err error
-				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				newEvent.EventType = "delete"
 				newEvent.ResourceType = handler.NetworkServiceResource
 				if err == nil {
@@ -320,7 +326,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 			AddFunc: func(obj interface{}) {
 				var newEvent handler.NsmEvent
 				var err error
-				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				newEvent.EventType = "create"
 				newEvent.ResourceType = handler.NetworkServiceChannelResource
 				if err == nil {
@@ -328,20 +334,26 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				var newEvent handler.NsmEvent
-				var err1, err2 error
-				newEvent.KeyOld, err2 = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-				newEvent.KeyCur, err1 = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
-				newEvent.EventType = "update"
-				newEvent.ResourceType = handler.NetworkServiceChannelResource
-				if err1 == nil && err2 == nil {
-					queueNSC.Add(newEvent)
+				// For an update event, we delete the old and add the current
+				var newEventOld, newEventCur handler.NsmEvent
+				var err error
+				newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+				newEventOld.EventType = "delete"
+				newEventOld.ResourceType = handler.NetworkServiceChannelResource
+				if err == nil {
+					queueNSC.Add(newEventOld)
+				}
+				newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
+				newEventCur.EventType = "create"
+				newEventCur.ResourceType = handler.NetworkServiceChannelResource
+				if err == nil {
+					queueNSC.Add(newEventCur)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				var newEvent handler.NsmEvent
 				var err error
-				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				newEvent.EventType = "delete"
 				newEvent.ResourceType = handler.NetworkServiceChannelResource
 				if err == nil {
@@ -382,7 +394,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 			AddFunc: func(obj interface{}) {
 				var newEvent handler.NsmEvent
 				var err error
-				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				newEvent.EventType = "create"
 				newEvent.ResourceType = handler.NetworkServiceEndpointResource
 				if err == nil {
@@ -390,20 +402,26 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				var newEvent handler.NsmEvent
-				var err1, err2 error
-				newEvent.KeyOld, err2 = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-				newEvent.KeyCur, err1 = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
-				newEvent.EventType = "update"
-				newEvent.ResourceType = handler.NetworkServiceEndpointResource
-				if err1 == nil && err2 == nil {
-					queueNSE.Add(newEvent)
+				// For an update event, we delete the old and add the current
+				var newEventOld, newEventCur handler.NsmEvent
+				var err error
+				newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+				newEventOld.EventType = "delete"
+				newEventOld.ResourceType = handler.NetworkServiceEndpointResource
+				if err == nil {
+					queueNSE.Add(newEventOld)
+				}
+				newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
+				newEventCur.EventType = "create"
+				newEventCur.ResourceType = handler.NetworkServiceEndpointResource
+				if err == nil {
+					queueNSE.Add(newEventCur)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				var newEvent handler.NsmEvent
 				var err error
-				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				newEvent.EventType = "delete"
 				newEvent.ResourceType = handler.NetworkServiceEndpointResource
 				if err == nil {

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -315,7 +315,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 
 	plugin.informerNSC = plugin.sharedFactoryNSC.Networkservice().V1().NetworkServiceChannels().Informer()
 	// we add a new event handler, watching for changes to API resources.
-	plugin.informerNS.AddEventHandler(
+	plugin.informerNSC.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				var newEvent handler.NsmEvent
@@ -377,7 +377,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 
 	plugin.informerNSE = plugin.sharedFactoryNSE.Networkservice().V1().NetworkServiceEndpoints().Informer()
 	// we add a new event handler, watching for changes to API resources.
-	plugin.informerNS.AddEventHandler(
+	plugin.informerNSE.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				var newEvent handler.NsmEvent

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -324,7 +324,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 				newEvent.EventType = "create"
 				newEvent.ResourceType = handler.NetworkServiceChannelResource
 				if err == nil {
-					queueNS.Add(newEvent)
+					queueNSC.Add(newEvent)
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
@@ -335,7 +335,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 				newEvent.EventType = "update"
 				newEvent.ResourceType = handler.NetworkServiceChannelResource
 				if err1 == nil && err2 == nil {
-					queueNS.Add(newEvent)
+					queueNSC.Add(newEvent)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -345,7 +345,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 				newEvent.EventType = "delete"
 				newEvent.ResourceType = handler.NetworkServiceChannelResource
 				if err == nil {
-					queueNS.Add(newEvent)
+					queueNSC.Add(newEvent)
 				}
 			},
 		},
@@ -386,7 +386,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 				newEvent.EventType = "create"
 				newEvent.ResourceType = handler.NetworkServiceEndpointResource
 				if err == nil {
-					queueNS.Add(newEvent)
+					queueNSE.Add(newEvent)
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
@@ -397,7 +397,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 				newEvent.EventType = "update"
 				newEvent.ResourceType = handler.NetworkServiceEndpointResource
 				if err1 == nil && err2 == nil {
-					queueNS.Add(newEvent)
+					queueNSE.Add(newEvent)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -407,7 +407,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 				newEvent.EventType = "delete"
 				newEvent.ResourceType = handler.NetworkServiceEndpointResource
 				if err == nil {
-					queueNS.Add(newEvent)
+					queueNSE.Add(newEvent)
 				}
 			},
 		},

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -455,10 +455,16 @@ func (plugin *Plugin) AfterInit() error {
 	plugin.sharedFactory.Start(plugin.stopChNS)
 	plugin.Log.Info("Started NetworkService informer factory.")
 
-	// Wait for the informer cache to finish performing it's initial sync of
+	// Wait for the informer caches to finish performing it's initial sync of
 	// resources
 	if !cache.WaitForCacheSync(plugin.stopChNS, plugin.informerNS.HasSynced) {
-		plugin.Log.Error("Error waiting for informer cache to sync")
+		plugin.Log.Error("Error waiting for NetworkService informer cache to sync")
+	}
+	if !cache.WaitForCacheSync(plugin.stopChNSC, plugin.informerNSC.HasSynced) {
+		plugin.Log.Error("Error waiting for NetworkServiceChannel informer cache to sync")
+	}
+	if !cache.WaitForCacheSync(plugin.stopChNSE, plugin.informerNSE.HasSynced) {
+		plugin.Log.Error("Error waiting for NetworkServiceEndpoint informer cache to sync")
 	}
 
 	plugin.Log.Info("NetworkService Informer is ready")

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -259,7 +259,7 @@ func informerNetworkServices(plugin *Plugin) {
 				var newEvent handler.NsmEvent
 				var err error
 				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				newEvent.EventType = "create"
+				newEvent.EventType = handler.HandlerCreate
 				newEvent.ResourceType = handler.NetworkServiceResource
 				if err == nil {
 					queueNS.Add(newEvent)
@@ -271,13 +271,13 @@ func informerNetworkServices(plugin *Plugin) {
 					var newEventOld, newEventCur handler.NsmEvent
 					var err error
 					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-					newEventOld.EventType = "delete"
+					newEventOld.EventType = handler.HandlerDelete
 					newEventOld.ResourceType = handler.NetworkServiceResource
 					if err == nil {
 						queueNS.Add(newEventOld)
 					}
 					newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
-					newEventCur.EventType = "create"
+					newEventCur.EventType = handler.HandlerCreate
 					newEventCur.ResourceType = handler.NetworkServiceResource
 					if err == nil {
 						queueNS.Add(newEventCur)
@@ -288,7 +288,7 @@ func informerNetworkServices(plugin *Plugin) {
 				var newEvent handler.NsmEvent
 				var err error
 				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				newEvent.EventType = "delete"
+				newEvent.EventType = handler.HandlerDelete
 				newEvent.ResourceType = handler.NetworkServiceResource
 				if err == nil {
 					queueNS.Add(newEvent)
@@ -329,7 +329,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 				var newEvent handler.NsmEvent
 				var err error
 				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				newEvent.EventType = "create"
+				newEvent.EventType = handler.HandlerCreate
 				newEvent.ResourceType = handler.NetworkServiceChannelResource
 				if err == nil {
 					queueNSC.Add(newEvent)
@@ -341,13 +341,13 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 					var newEventOld, newEventCur handler.NsmEvent
 					var err error
 					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-					newEventOld.EventType = "delete"
+					newEventOld.EventType = handler.HandlerDelete
 					newEventOld.ResourceType = handler.NetworkServiceChannelResource
 					if err == nil {
 						queueNSC.Add(newEventOld)
 					}
 					newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
-					newEventCur.EventType = "create"
+					newEventCur.EventType = handler.HandlerCreate
 					newEventCur.ResourceType = handler.NetworkServiceChannelResource
 					if err == nil {
 						queueNSC.Add(newEventCur)
@@ -358,7 +358,7 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 				var newEvent handler.NsmEvent
 				var err error
 				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				newEvent.EventType = "delete"
+				newEvent.EventType = handler.HandlerDelete
 				newEvent.ResourceType = handler.NetworkServiceChannelResource
 				if err == nil {
 					queueNSC.Add(newEvent)
@@ -399,7 +399,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 				var newEvent handler.NsmEvent
 				var err error
 				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				newEvent.EventType = "create"
+				newEvent.EventType = handler.HandlerCreate
 				newEvent.ResourceType = handler.NetworkServiceEndpointResource
 				if err == nil {
 					queueNSE.Add(newEvent)
@@ -411,13 +411,13 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 					var newEventOld, newEventCur handler.NsmEvent
 					var err error
 					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-					newEventOld.EventType = "delete"
+					newEventOld.EventType = handler.HandlerDelete
 					newEventOld.ResourceType = handler.NetworkServiceEndpointResource
 					if err == nil {
 						queueNSE.Add(newEventOld)
 					}
 					newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
-					newEventCur.EventType = "create"
+					newEventCur.EventType = handler.HandlerCreate
 					newEventCur.ResourceType = handler.NetworkServiceEndpointResource
 					if err == nil {
 						queueNSE.Add(newEventCur)
@@ -428,7 +428,7 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 				var newEvent handler.NsmEvent
 				var err error
 				newEvent.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				newEvent.EventType = "delete"
+				newEvent.EventType = handler.HandlerDelete
 				newEvent.ResourceType = handler.NetworkServiceEndpointResource
 				if err == nil {
 					queueNSE.Add(newEvent)

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -266,20 +266,22 @@ func informerNetworkServices(plugin *Plugin) {
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				// For an update event, we delete the old and add the current
-				var newEventOld, newEventCur handler.NsmEvent
-				var err error
-				newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-				newEventOld.EventType = "delete"
-				newEventOld.ResourceType = handler.NetworkServiceResource
-				if err == nil {
-					queueNS.Add(newEventOld)
-				}
-				newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
-				newEventCur.EventType = "create"
-				newEventCur.ResourceType = handler.NetworkServiceResource
-				if err == nil {
-					queueNS.Add(newEventCur)
+				if reflect.DeepEqual(old, cur) {
+					// For an update event, we delete the old and add the current
+					var newEventOld, newEventCur handler.NsmEvent
+					var err error
+					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+					newEventOld.EventType = "delete"
+					newEventOld.ResourceType = handler.NetworkServiceResource
+					if err == nil {
+						queueNS.Add(newEventOld)
+					}
+					newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
+					newEventCur.EventType = "create"
+					newEventCur.ResourceType = handler.NetworkServiceResource
+					if err == nil {
+						queueNS.Add(newEventCur)
+					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -334,20 +336,22 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				// For an update event, we delete the old and add the current
-				var newEventOld, newEventCur handler.NsmEvent
-				var err error
-				newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-				newEventOld.EventType = "delete"
-				newEventOld.ResourceType = handler.NetworkServiceChannelResource
-				if err == nil {
-					queueNSC.Add(newEventOld)
-				}
-				newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
-				newEventCur.EventType = "create"
-				newEventCur.ResourceType = handler.NetworkServiceChannelResource
-				if err == nil {
-					queueNSC.Add(newEventCur)
+				if reflect.DeepEqual(old, cur) {
+					// For an update event, we delete the old and add the current
+					var newEventOld, newEventCur handler.NsmEvent
+					var err error
+					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+					newEventOld.EventType = "delete"
+					newEventOld.ResourceType = handler.NetworkServiceChannelResource
+					if err == nil {
+						queueNSC.Add(newEventOld)
+					}
+					newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
+					newEventCur.EventType = "create"
+					newEventCur.ResourceType = handler.NetworkServiceChannelResource
+					if err == nil {
+						queueNSC.Add(newEventCur)
+					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -402,20 +406,22 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				// For an update event, we delete the old and add the current
-				var newEventOld, newEventCur handler.NsmEvent
-				var err error
-				newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-				newEventOld.EventType = "delete"
-				newEventOld.ResourceType = handler.NetworkServiceEndpointResource
-				if err == nil {
-					queueNSE.Add(newEventOld)
-				}
-				newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
-				newEventCur.EventType = "create"
-				newEventCur.ResourceType = handler.NetworkServiceEndpointResource
-				if err == nil {
-					queueNSE.Add(newEventCur)
+				if reflect.DeepEqual(old, cur) {
+					// For an update event, we delete the old and add the current
+					var newEventOld, newEventCur handler.NsmEvent
+					var err error
+					newEventOld.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+					newEventOld.EventType = "delete"
+					newEventOld.ResourceType = handler.NetworkServiceEndpointResource
+					if err == nil {
+						queueNSE.Add(newEventOld)
+					}
+					newEventCur.Key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
+					newEventCur.EventType = "create"
+					newEventCur.ResourceType = handler.NetworkServiceEndpointResource
+					if err == nil {
+						queueNSE.Add(newEventCur)
+					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -255,13 +255,37 @@ func informerNetworkServices(plugin *Plugin) {
 	// We add a new event handler, watching for changes to API resources.
 	plugin.informerNS.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: networkserviceEnqueue,
-			UpdateFunc: func(old, cur interface{}) {
-				if !reflect.DeepEqual(old, cur) {
-					networkserviceEnqueue(cur)
+			AddFunc: func(obj interface{}) {
+				var newEvent handler.NsmEvent
+				var err error
+				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.EventType = "create"
+				newEvent.ResourceType = handler.NetworkServiceResource
+				if err == nil {
+					queueNS.Add(newEvent)
 				}
 			},
-			DeleteFunc: networkserviceEnqueue,
+			UpdateFunc: func(old, cur interface{}) {
+				var newEvent handler.NsmEvent
+				var err1, err2 error
+				newEvent.KeyOld, err2 = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+				newEvent.KeyCur, err1 = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
+				newEvent.EventType = "update"
+				newEvent.ResourceType = handler.NetworkServiceResource
+				if err1 == nil && err2 == nil {
+					queueNS.Add(newEvent)
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				var newEvent handler.NsmEvent
+				var err error
+				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.EventType = "delete"
+				newEvent.ResourceType = handler.NetworkServiceResource
+				if err == nil {
+					queueNS.Add(newEvent)
+				}
+			},
 		},
 	)
 
@@ -291,15 +315,39 @@ func informerNetworkServiceChannels(plugin *Plugin) {
 
 	plugin.informerNSC = plugin.sharedFactoryNSC.Networkservice().V1().NetworkServiceChannels().Informer()
 	// we add a new event handler, watching for changes to API resources.
-	plugin.informerNSC.AddEventHandler(
+	plugin.informerNS.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: networkservicechannelEnqueue,
-			UpdateFunc: func(old, cur interface{}) {
-				if !reflect.DeepEqual(old, cur) {
-					networkservicechannelEnqueue(cur)
+			AddFunc: func(obj interface{}) {
+				var newEvent handler.NsmEvent
+				var err error
+				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.EventType = "create"
+				newEvent.ResourceType = handler.NetworkServiceChannelResource
+				if err == nil {
+					queueNS.Add(newEvent)
 				}
 			},
-			DeleteFunc: networkservicechannelEnqueue,
+			UpdateFunc: func(old, cur interface{}) {
+				var newEvent handler.NsmEvent
+				var err1, err2 error
+				newEvent.KeyOld, err2 = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+				newEvent.KeyCur, err1 = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
+				newEvent.EventType = "update"
+				newEvent.ResourceType = handler.NetworkServiceChannelResource
+				if err1 == nil && err2 == nil {
+					queueNS.Add(newEvent)
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				var newEvent handler.NsmEvent
+				var err error
+				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.EventType = "delete"
+				newEvent.ResourceType = handler.NetworkServiceChannelResource
+				if err == nil {
+					queueNS.Add(newEvent)
+				}
+			},
 		},
 	)
 
@@ -329,15 +377,39 @@ func informerNetworkServiceEndpoints(plugin *Plugin) {
 
 	plugin.informerNSE = plugin.sharedFactoryNSE.Networkservice().V1().NetworkServiceEndpoints().Informer()
 	// we add a new event handler, watching for changes to API resources.
-	plugin.informerNSE.AddEventHandler(
+	plugin.informerNS.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: networkserviceendpointEnqueue,
-			UpdateFunc: func(old, cur interface{}) {
-				if !reflect.DeepEqual(old, cur) {
-					networkserviceendpointEnqueue(cur)
+			AddFunc: func(obj interface{}) {
+				var newEvent handler.NsmEvent
+				var err error
+				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.EventType = "create"
+				newEvent.ResourceType = handler.NetworkServiceEndpointResource
+				if err == nil {
+					queueNS.Add(newEvent)
 				}
 			},
-			DeleteFunc: networkserviceendpointEnqueue,
+			UpdateFunc: func(old, cur interface{}) {
+				var newEvent handler.NsmEvent
+				var err1, err2 error
+				newEvent.KeyOld, err2 = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
+				newEvent.KeyCur, err1 = cache.DeletionHandlingMetaNamespaceKeyFunc(cur)
+				newEvent.EventType = "update"
+				newEvent.ResourceType = handler.NetworkServiceEndpointResource
+				if err1 == nil && err2 == nil {
+					queueNS.Add(newEvent)
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				var newEvent handler.NsmEvent
+				var err error
+				newEvent.KeyCur, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				newEvent.EventType = "delete"
+				newEvent.ResourceType = handler.NetworkServiceEndpointResource
+				if err == nil {
+					queueNS.Add(newEvent)
+				}
+			},
 		},
 	)
 

--- a/plugins/handler/plugin_api_handler.go
+++ b/plugins/handler/plugin_api_handler.go
@@ -23,15 +23,9 @@ const (
 	HandlerUpdate                  = "update"
 )
 
-type NsmEvent struct {
-	Key          string
-	EventType    string
-	ResourceType string
-}
-
 // API is the interface to a CRD handler plugin
 type API interface {
-	ObjectCreated(obj interface{}, event NsmEvent)
-	ObjectDeleted(obj interface{}, event NsmEvent)
-	ObjectUpdated(objOld, objNew interface{}, event NsmEvent)
+	ObjectCreated(obj interface{})
+	ObjectDeleted(obj interface{})
+	ObjectUpdated(objOld, objNew interface{})
 }

--- a/plugins/handler/plugin_api_handler.go
+++ b/plugins/handler/plugin_api_handler.go
@@ -14,15 +14,6 @@
 
 package handler
 
-const (
-	NetworkServiceResource         = "networkservice"
-	NetworkServiceChannelResource  = "networkservicechannel"
-	NetworkServiceEndpointResource = "networkserviceendpoint"
-	HandlerCreate                  = "create"
-	HandlerDelete                  = "delete"
-	HandlerUpdate                  = "update"
-)
-
 // API is the interface to a CRD handler plugin
 type API interface {
 	ObjectCreated(obj interface{})

--- a/plugins/handler/plugin_api_handler.go
+++ b/plugins/handler/plugin_api_handler.go
@@ -14,9 +14,22 @@
 
 package handler
 
+const (
+	NetworkServiceResource         = "networkservice"
+	NetworkServiceChannelResource  = "networkservicechannel"
+	NetworkServiceEndpointResource = "networkserviceendpoint"
+)
+
+type NsmEvent struct {
+	KeyOld       string
+	KeyCur       string
+	EventType    string
+	ResourceType string
+}
+
 // API is the interface to a CRD handler plugin
 type API interface {
-	ObjectCreated(obj interface{})
-	ObjectDeleted(obj interface{})
-	ObjectUpdated(objOld, objNew interface{})
+	ObjectCreated(obj interface{}, event NsmEvent)
+	ObjectDeleted(obj interface{}, event NsmEvent)
+	ObjectUpdated(objOld, objNew interface{}, event NsmEvent)
 }

--- a/plugins/handler/plugin_api_handler.go
+++ b/plugins/handler/plugin_api_handler.go
@@ -26,7 +26,7 @@ const (
 type NsmEvent struct {
 	Key          string
 	EventType    string
-	ResourceType interface{}
+	ResourceType string
 }
 
 // API is the interface to a CRD handler plugin

--- a/plugins/handler/plugin_api_handler.go
+++ b/plugins/handler/plugin_api_handler.go
@@ -26,7 +26,7 @@ const (
 type NsmEvent struct {
 	Key          string
 	EventType    string
-	ResourceType string
+	ResourceType interface{}
 }
 
 // API is the interface to a CRD handler plugin

--- a/plugins/handler/plugin_api_handler.go
+++ b/plugins/handler/plugin_api_handler.go
@@ -18,6 +18,9 @@ const (
 	NetworkServiceResource         = "networkservice"
 	NetworkServiceChannelResource  = "networkservicechannel"
 	NetworkServiceEndpointResource = "networkserviceendpoint"
+	HandlerCreate                  = "create"
+	HandlerDelete                  = "delete"
+	HandlerUpdate                  = "update"
 )
 
 type NsmEvent struct {

--- a/plugins/handler/plugin_api_handler.go
+++ b/plugins/handler/plugin_api_handler.go
@@ -21,8 +21,7 @@ const (
 )
 
 type NsmEvent struct {
-	KeyOld       string
-	KeyCur       string
+	Key          string
 	EventType    string
 	ResourceType string
 }

--- a/plugins/handler/plugin_impl_handler.go
+++ b/plugins/handler/plugin_impl_handler.go
@@ -77,16 +77,16 @@ func (p *Plugin) Close() error {
 }
 
 // ObjectCreated is called when an object is created
-func (p *Plugin) ObjectCreated(obj interface{}) {
-	p.Log.Infof("LogCrdHandler.ObjectCreated: ", obj)
+func (p *Plugin) ObjectCreated(obj interface{}, event NsmEvent) {
+	p.Log.Infof("LogCrdHandler.ObjectCreated: ", obj, event)
 }
 
 // ObjectDeleted is called when an object is deleted
-func (p *Plugin) ObjectDeleted(obj interface{}) {
-	p.Log.Infof("LogCrdHandler.ObjectDeleted: ", obj)
+func (p *Plugin) ObjectDeleted(obj interface{}, event NsmEvent) {
+	p.Log.Infof("LogCrdHandler.ObjectDeleted: ", obj, event)
 }
 
 // ObjectUpdated is called when an object is updated
-func (p *Plugin) ObjectUpdated(objOld, objNew interface{}) {
-	p.Log.Infof("LogCrdHandler.ObjectUpdated: ", objNew)
+func (p *Plugin) ObjectUpdated(objOld, objNew interface{}, event NsmEvent) {
+	p.Log.Infof("LogCrdHandler.ObjectUpdated: ", objNew, event)
 }

--- a/plugins/handler/plugin_impl_handler.go
+++ b/plugins/handler/plugin_impl_handler.go
@@ -77,16 +77,16 @@ func (p *Plugin) Close() error {
 }
 
 // ObjectCreated is called when an object is created
-func (p *Plugin) ObjectCreated(obj interface{}, event NsmEvent) {
-	p.Log.Infof("LogCrdHandler.ObjectCreated: ", obj, event)
+func (p *Plugin) ObjectCreated(obj interface{}) {
+	p.Log.Infof("LogCrdHandler.ObjectCreated: ", obj)
 }
 
 // ObjectDeleted is called when an object is deleted
-func (p *Plugin) ObjectDeleted(obj interface{}, event NsmEvent) {
-	p.Log.Infof("LogCrdHandler.ObjectDeleted: ", obj, event)
+func (p *Plugin) ObjectDeleted(obj interface{}) {
+	p.Log.Infof("LogCrdHandler.ObjectDeleted: ", obj)
 }
 
 // ObjectUpdated is called when an object is updated
-func (p *Plugin) ObjectUpdated(objOld, objNew interface{}, event NsmEvent) {
-	p.Log.Infof("LogCrdHandler.ObjectUpdated: ", objOld, objNew, event)
+func (p *Plugin) ObjectUpdated(objOld, objNew interface{}) {
+	p.Log.Infof("LogCrdHandler.ObjectUpdated: ", objOld, objNew)
 }

--- a/plugins/handler/plugin_impl_handler.go
+++ b/plugins/handler/plugin_impl_handler.go
@@ -78,15 +78,15 @@ func (p *Plugin) Close() error {
 
 // ObjectCreated is called when an object is created
 func (p *Plugin) ObjectCreated(obj interface{}) {
-	p.Log.Infof("LogCrdHandler.ObjectCreated: %s", obj)
+	p.Log.Infof("LogCrdHandler.ObjectCreated: ", obj)
 }
 
 // ObjectDeleted is called when an object is deleted
 func (p *Plugin) ObjectDeleted(obj interface{}) {
-	p.Log.Infof("LogCrdHandler.ObjectDeleted: %s", obj)
+	p.Log.Infof("LogCrdHandler.ObjectDeleted: ", obj)
 }
 
 // ObjectUpdated is called when an object is updated
 func (p *Plugin) ObjectUpdated(objOld, objNew interface{}) {
-	p.Log.Infof("LogCrdHandler.ObjectUpdated: %s", objNew)
+	p.Log.Infof("LogCrdHandler.ObjectUpdated: ", objNew)
 }

--- a/plugins/handler/plugin_impl_handler.go
+++ b/plugins/handler/plugin_impl_handler.go
@@ -88,5 +88,5 @@ func (p *Plugin) ObjectDeleted(obj interface{}, event NsmEvent) {
 
 // ObjectUpdated is called when an object is updated
 func (p *Plugin) ObjectUpdated(objOld, objNew interface{}, event NsmEvent) {
-	p.Log.Infof("LogCrdHandler.ObjectUpdated: ", objNew, event)
+	p.Log.Infof("LogCrdHandler.ObjectUpdated: ", objOld, objNew, event)
 }


### PR DESCRIPTION
This closes #115.

Create Events to store in the worker queue for CRD operations. This allows us to store metadata with each object, making it easier to eventually interface and interact with the object store.