### PR TITLE
Adding ConfigMap parsing code

### DIFF
--- a/cmd/nsm-init/nsm-init.go
+++ b/cmd/nsm-init/nsm-init.go
@@ -133,6 +133,7 @@ func parseConfigMap(cm *v1.ConfigMap) ([]*networkService, error) {
 	decoder := yaml.NewYAMLOrJSONDecoder(sr, 512)
 	if err := decoder.Decode(&nSs); err != nil {
 		logrus.Errorf("decoding %+v failed with error: %v", rawData, err)
+		return nil, err
 	}
 
 	return nSs, nil

--- a/cmd/nsm-init/nsm-init.go
+++ b/cmd/nsm-init/nsm-init.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"net"
 	"os"
@@ -29,6 +30,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -39,7 +45,14 @@ const (
 var (
 	clientSocketPath     = path.Join(nsmdp.SocketBaseDir, nsmdp.ServerSock)
 	clientSocketUserPath = flag.String("nsm-socket", "", "Location of NSM process client access socket")
+	configMapName        = flag.String("configmap-name", "", "Name of a ConfigMap with requested configuration.")
+	kubeconfig           = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Either this or master needs to be set if the provisioner is being run out of cluster.")
 )
+
+type networkService struct {
+	name             string
+	serviceInterface []*nsmconnect.Interface
+}
 
 func dial(ctx context.Context, unixSocketPath string) (*grpc.ClientConn, error) {
 	c, err := grpc.DialContext(ctx, unixSocketPath, grpc.WithInsecure(), grpc.WithBlock(),
@@ -51,34 +64,37 @@ func dial(ctx context.Context, unixSocketPath string) (*grpc.ClientConn, error) 
 	return c, err
 }
 
-func main() {
-	flag.Parse()
-	flag.Set("logtostderr", "true")
+func checkClientConfigMap(name, namespace string, k8s kubernetes.Interface) (*v1.ConfigMap, error) {
+	return k8s.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
+}
 
-	// Checking if nsm client socket exists and of not crash init container
-	clientSocket := clientSocketPath
-	if clientSocketUserPath != nil {
-		clientSocket = *clientSocketUserPath
+func buildClient() (*kubernetes.Clientset, error) {
+	var config *rest.Config
+	var err error
+
+	kubeconfigEnv := os.Getenv("KUBECONFIG")
+
+	if kubeconfigEnv != "" {
+		kubeconfig = &kubeconfigEnv
 	}
-	_, err := os.Stat(clientSocket)
+
+	if *kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	} else {
+		config, err = rest.InClusterConfig()
+	}
 	if err != nil {
-		logrus.Errorf("nsm client: failure to access nsm socket at %s with error: %+v, existing...", clientSocket, err)
-		os.Exit(1)
+		return nil, err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), clientConnectionTimeout)
-	conn, err := dial(ctx, clientSocket)
+	k8s, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		logrus.Errorf("nsm client: failure to communicate with the socket %s with error: %+v", clientSocket, err)
-		os.Exit(1)
+		return nil, err
 	}
-	nsmClient := nsmconnect.NewClientConnectionClient(conn)
-	defer conn.Close()
-	defer cancel()
-	logrus.Infof("nsm client: connection to nsm server on socket: %s succeeded.", clientSocket)
-	logrus.Infof("nsm client: client api %+v", nsmClient)
-	// Init related activities start here
 
+	return k8s, nil
+}
+
+func applyRequiredConfig(ns []*networkService) error {
 	currentNamespace, err := netns.Get()
 	if err != nil {
 		logrus.Errorf("nsm client: failure to get pod's namespace with error: %+v", err)
@@ -97,6 +113,96 @@ func main() {
 	logrus.Info("nsm client: pod's interfaces:")
 	for _, intf := range interfaces {
 		logrus.Infof("Name: %s Type: %s", intf.Attrs().Name, intf.Type())
+	}
+	logrus.Info("nsm client: requested network services:")
+	for _, s := range ns {
+		logrus.Infof("%+v", s)
+	}
+	return nil
+}
+
+func parseConfigMap(cm *v1.ConfigMap) ([]*networkService, error) {
+	nSs := []*networkService{}
+	for key, val := range cm.Data {
+		ns := networkService{}
+		err := json.Unmarshal([]byte(val), &ns)
+		if err != nil {
+			logrus.Errorf("corrupted value of key: %s, failed with error: %v", key, err)
+			continue
+		}
+		nSs = append(nSs, &ns)
+	}
+	return nSs, nil
+}
+
+func main() {
+	flag.Parse()
+	flag.Set("logtostderr", "true")
+
+	// Building kubernetes client
+	k8s, err := buildClient()
+	if err != nil {
+		logrus.Errorf("nsm client: fail to build kubernetes client with error: %+v, exiting...", err)
+		os.Exit(1)
+	}
+
+	// Checking presence of client's ConfigMap, if it is not provided, then init container gracefully exits
+	if *configMapName == "" {
+		logrus.Info("nsm client: no client's configmap name was provided, exiting...")
+		os.Exit(0)
+	}
+	name := *configMapName
+	// POD's namespace is taken from env variable, which must be either defined via downward api for in-cluster case
+	// or explicitely exported for out-of-cluster case.
+	namespace := os.Getenv("INIT_NAMESPACE")
+	if namespace == "" {
+		logrus.Error("nsm client: cannot detect namespace, make sure INIT_NAMESPACE variable is set via downward api, exiting...")
+		os.Exit(1)
+	}
+	configMap, err := checkClientConfigMap(name, namespace, k8s)
+	if err != nil {
+		logrus.Errorf("nsm client: failure to access client's configmap at %s/%s with error: %+v, exiting...", namespace, name, err)
+		os.Exit(1)
+	}
+	// Attempting to extract Client's config from the config map and store it in networkService slice
+	ns, err := parseConfigMap(configMap)
+	if err != nil {
+		logrus.Errorf("nsm client: failure to parse client's configmap %s/%s with error: %+v, exiting...", namespace, name, err)
+		os.Exit(1)
+	}
+	// Checking number of NetworkServices extracted from the config map and if it is 0 then
+	// print log message and gracefully exit
+	if len(ns) == 0 {
+		logrus.Infof("nsm client: no NetworkServices were discovered in client's configmap %s/%s, exiting...", namespace, name)
+		os.Exit(0)
+	}
+	// Checking if nsm client socket exists and of not crash init container
+	clientSocket := clientSocketPath
+	if clientSocketUserPath != nil {
+		clientSocket = *clientSocketUserPath
+	}
+
+	if _, err := os.Stat(clientSocket); err != nil {
+		logrus.Errorf("nsm client: failure to access nsm socket at %s with error: %+v, exiting...", clientSocket, err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), clientConnectionTimeout)
+	conn, err := dial(ctx, clientSocket)
+	if err != nil {
+		logrus.Errorf("nsm client: failure to communicate with the socket %s with error: %+v", clientSocket, err)
+		os.Exit(1)
+	}
+	nsmClient := nsmconnect.NewClientConnectionClient(conn)
+	defer conn.Close()
+	defer cancel()
+	logrus.Infof("nsm client: connection to nsm server on socket: %s succeeded.", clientSocket)
+	logrus.Infof("nsm client: client api %+v", nsmClient)
+	// Init related activities start here
+
+	if err := applyRequiredConfig(ns); err != nil {
+		logrus.Infof("nsm client: initialization failed, exiting...", err)
+		os.Exit(1)
 	}
 	// Init related activities ends here
 	logrus.Info("nsm client: initialization is completed successfully, exiting...")

--- a/cmd/nsm-init/nsm-init.go
+++ b/cmd/nsm-init/nsm-init.go
@@ -205,10 +205,9 @@ func main() {
 	// Init related activities start here
 
 	if err := applyRequiredConfig(ns); err != nil {
-		logrus.Infof("nsm client: initialization failed, exiting...", err)
+		logrus.Fatalf("nsm client: initialization failed, exiting...", err)
 		os.Exit(1)
 	}
 	// Init related activities ends here
 	logrus.Info("nsm client: initialization is completed successfully, exiting...")
-	os.Exit(0)
 }

--- a/conf/sample/nsm-client.yaml
+++ b/conf/sample/nsm-client.yaml
@@ -1,3 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: nsm-client-init
+  name: nsm-client-init
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: nsm-client-init
+  name: nsm-client-init
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: nsm-client-init
+  name: nsm-client-init
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nsm-client-init
+subjects:
+- kind: ServiceAccount
+  name: nsm-client-init
+---
+apiVersion: v1
+data:
+  networkService: |
+    - name: network-service-1
+      serviceInterface:
+      - type: 0
+        preference: 1
+        metadata:
+          name: interface-1
+      - type: 2
+        preference: 3
+        metadata:
+          name: interface-2
+    - name: network-service-2
+      serviceInterface:
+      - type: 0
+        preference: 1
+        metadata:
+          name: interface-3
+kind: ConfigMap
+metadata:
+  name: client-network-services
+  namespace: default
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 spec:
@@ -7,6 +70,7 @@ spec:
       labels:
         app: nsm-client
     spec:
+      serviceAccount: nsm-client-init
       initContainers:
         - name: nsm-init
           image: ligato/networkservicemesh/nsm-init:latest
@@ -17,6 +81,7 @@ spec:
               add: ["NET_ADMIN"]
           args:
           - --nsm-socket=/var/lib/networkservicemesh/nsm.ligato.io.sock
+          - --configmap-name=client-network-services
           resources:
             limits:
               nsm.ligato.io/socket: 1

--- a/conf/sample/nsm-client.yaml
+++ b/conf/sample/nsm-client.yaml
@@ -20,6 +20,11 @@ spec:
           resources:
             limits:
               nsm.ligato.io/socket: 1
+          env:
+          - name: INIT_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       containers:
         - image: alpine
           name: nsm-client


### PR DESCRIPTION
This PR adds nsm-init container an ability to get client's desired NetworkServices from k8s ConfigMap.
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>