### PR TITLE
Add support for listing CRD objects

### DIFF
--- a/plugins/crd/plugin_api_crd.go
+++ b/plugins/crd/plugin_api_crd.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netmeshplugincrd
+
+import (
+	v1 "github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// API is the interface to a CRD plugin
+type API interface {
+	ListNetworkServices(selector labels.Selector) (ret []*v1.NetworkService, err error)
+	ListNetworkServiceChannels(selector labels.Selector) (ret []*v1.NetworkServiceChannel, err error)
+	ListNetworkServiceEndpoints(selector labels.Selector) (ret []*v1.NetworkServiceEndpoint, err error)
+}


### PR DESCRIPTION
The shared informer we use is a cache of API objects. Currently, we simply
make use of the cache for Create/Update/Delete operations, but we can use
a generated Lister() to traverse the cache. This patch exposes this
functionality as an API from the CRD Plugin.

Note that I need to convert the CRD plugin into an idempotent plugin for
this to be useful, as there is a circular dependency at the moment: The
CRD plugin uses the handler plugin API, and the handler would need to
call the CRD list APIs.

Signed-off-by: Kyle Mestery <mestery@mestery.com>