### PR TITLE
Add channels and endpoints into the objectstore

### DIFF
--- a/plugins/objectstore/networkservice_test.go
+++ b/plugins/objectstore/networkservice_test.go
@@ -36,10 +36,6 @@ func TestNetworkServiceStore(t *testing.T) {
 	networkservices.networkServicesStore = newNetworkServicesStore()
 
 	ns := netmesh.NetworkService{
-		Metadata: &netmesh.Metadata{},
-	}
-
-	ns = netmesh.NetworkService{
 		Metadata: &netmesh.Metadata{
 			Name:      nsTestName,
 			Namespace: nsTestNamespace,

--- a/plugins/objectstore/networkservice_test.go
+++ b/plugins/objectstore/networkservice_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstore
+
+import (
+	"testing"
+
+	"github.com/ligato/networkservicemesh/netmesh/model/netmesh"
+)
+
+type networkserviceStore struct {
+	*networkServicesStore
+}
+
+const (
+	nsTestName      = "EndpointTest"
+	nsTestNamespace = "default"
+)
+
+var networkservices *networkserviceStore
+
+func TestNetworkServiceStore(t *testing.T) {
+	networkservices := &networkserviceStore{}
+	networkservices.networkServicesStore = newNetworkServicesStore()
+
+	ns := netmesh.NetworkService{
+		Metadata: &netmesh.Metadata{},
+	}
+
+	ns = netmesh.NetworkService{
+		Metadata: &netmesh.Metadata{
+			Name:      nsTestName,
+			Namespace: nsTestNamespace,
+		},
+	}
+
+	networkservices.networkServicesStore.Add(&ns)
+
+	for _, n := range networkservices.networkServicesStore.List() {
+		if n.Metadata.Name != nsTestName {
+			t.Errorf("Unexpected Name value returned when creating NetworkService")
+		}
+
+		if n.Metadata.Namespace != nsTestNamespace {
+			t.Errorf("Unexpected Namespace value returned when creating NetworkService")
+		}
+	}
+
+	networkservices.networkServicesStore.Delete(meta{name: ns.Metadata.Name, namespace: ns.Metadata.Namespace})
+
+	nsRet := networkservices.networkServicesStore.List()
+	if len(nsRet) != 0 {
+		t.Errorf("Deletion of NetworkService from objectstore failed")
+	}
+}

--- a/plugins/objectstore/networkservicechannels.go
+++ b/plugins/objectstore/networkservicechannels.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstore
+
+import (
+	"sync"
+
+	"github.com/ligato/networkservicemesh/netmesh/model/netmesh"
+)
+
+// NetworkServiceChannelsStore map stores all discovered Network Service Channel
+// Objects with a key composed of a name and a namespace
+type networkServiceChannelsStore struct {
+	networkServiceChannel map[meta]*netmesh.NetworkService_NetmeshChannel
+	sync.RWMutex
+}
+
+// NewNetworkServiceChannelsStore instantiates a new instance of a global
+// NetworkServiceChannels store. It must be initialized before any controllers start.
+func newNetworkServiceChannelsStore() *networkServiceChannelsStore {
+	return &networkServiceChannelsStore{
+		networkServiceChannel: map[meta]*netmesh.NetworkService_NetmeshChannel{}}
+}
+
+// Add method adds descovered NetworkServiceChannel if it does not
+// already exit in the store.
+func (n *networkServiceChannelsStore) Add(ns *netmesh.NetworkService_NetmeshChannel) {
+	n.Lock()
+	defer n.Unlock()
+
+	key := meta{
+		name:      ns.Metadata.Name,
+		namespace: ns.Metadata.Namespace,
+	}
+	if _, ok := n.networkServiceChannel[key]; !ok {
+		// Not in the store, adding it.
+		n.networkServiceChannel[key] = ns
+	}
+}
+
+// Delete method deletes removed NetworkServiceChannel object from the store.
+func (n *networkServiceChannelsStore) Delete(key meta) {
+	n.Lock()
+	defer n.Unlock()
+
+	if _, ok := n.networkServiceChannel[key]; ok {
+		delete(n.networkServiceChannel, key)
+	}
+}
+
+// List method lists all known NetworkServiceChannel objects.
+func (n *networkServiceChannelsStore) List() []*netmesh.NetworkService_NetmeshChannel {
+	n.Lock()
+	defer n.Unlock()
+	networkServiceChannels := []*netmesh.NetworkService_NetmeshChannel{}
+	for _, ns := range n.networkServiceChannel {
+		networkServiceChannels = append(networkServiceChannels, ns)
+	}
+
+	return networkServiceChannels
+}

--- a/plugins/objectstore/networkservicechannels_test.go
+++ b/plugins/objectstore/networkservicechannels_test.go
@@ -36,10 +36,6 @@ func TestChannelStore(t *testing.T) {
 	channels.networkServiceChannelsStore = newNetworkServiceChannelsStore()
 
 	nsc := netmesh.NetworkService_NetmeshChannel{
-		Metadata: &netmesh.Metadata{},
-	}
-
-	nsc = netmesh.NetworkService_NetmeshChannel{
 		Metadata: &netmesh.Metadata{
 			Name:      chTestName,
 			Namespace: chTestNamespace,

--- a/plugins/objectstore/networkservicechannels_test.go
+++ b/plugins/objectstore/networkservicechannels_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstore
+
+import (
+	"testing"
+
+	"github.com/ligato/networkservicemesh/netmesh/model/netmesh"
+)
+
+type channelStore struct {
+	*networkServiceChannelsStore
+}
+
+const (
+	chTestName      = "ChannelTest"
+	chTestNamespace = "default"
+)
+
+var channels *channelStore
+
+func TestChannelStore(t *testing.T) {
+	channels := &channelStore{}
+	channels.networkServiceChannelsStore = newNetworkServiceChannelsStore()
+
+	nsc := netmesh.NetworkService_NetmeshChannel{
+		Metadata: &netmesh.Metadata{},
+	}
+
+	nsc = netmesh.NetworkService_NetmeshChannel{
+		Metadata: &netmesh.Metadata{
+			Name:      chTestName,
+			Namespace: chTestNamespace,
+		},
+	}
+
+	channels.networkServiceChannelsStore.Add(&nsc)
+
+	for _, n := range channels.networkServiceChannelsStore.List() {
+		if n.Metadata.Name != chTestName {
+			t.Errorf("Unexpected Name value returned when creating NetworkServiceChannel")
+		}
+
+		if n.Metadata.Namespace != chTestNamespace {
+			t.Errorf("Unexpected Namespace value returned when creating NetworkServiceChannel")
+		}
+	}
+
+	channels.networkServiceChannelsStore.Delete(meta{name: nsc.Metadata.Name, namespace: nsc.Metadata.Namespace})
+
+	nscRet := channels.networkServiceChannelsStore.List()
+	if len(nscRet) != 0 {
+		t.Errorf("Deletion of NetworkServiceChannel from objectstore failed")
+	}
+}

--- a/plugins/objectstore/networkserviceendpoints.go
+++ b/plugins/objectstore/networkserviceendpoints.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstore
+
+import (
+	"sync"
+
+	"github.com/ligato/networkservicemesh/netmesh/model/netmesh"
+)
+
+// NetworkServiceEndpointsStore map stores all discovered Network Service Endpoint
+// Objects with a key composed of a name and a namespace
+type networkServiceEndpointsStore struct {
+	networkServiceEndpoint map[meta]*netmesh.NetworkServiceEndpoint
+	sync.RWMutex
+}
+
+// NewNetworkServiceEndpointsStore instantiates a new instance of a global
+// NetworkServiceEndpoints store. It must be initialized before any controllers start.
+func newNetworkServiceEndpointsStore() *networkServiceEndpointsStore {
+	return &networkServiceEndpointsStore{
+		networkServiceEndpoint: map[meta]*netmesh.NetworkServiceEndpoint{}}
+}
+
+// Add method adds descovered NetworkServiceEndpoint if it does not
+// already exit in the store.
+func (n *networkServiceEndpointsStore) Add(ns *netmesh.NetworkServiceEndpoint) {
+	n.Lock()
+	defer n.Unlock()
+
+	key := meta{
+		name:      ns.Metadata.Name,
+		namespace: ns.Metadata.Namespace,
+	}
+	if _, ok := n.networkServiceEndpoint[key]; !ok {
+		// Not in the store, adding it.
+		n.networkServiceEndpoint[key] = ns
+	}
+}
+
+// Delete method deletes removed NetworkServiceEndpoint object from the store.
+func (n *networkServiceEndpointsStore) Delete(key meta) {
+	n.Lock()
+	defer n.Unlock()
+
+	if _, ok := n.networkServiceEndpoint[key]; ok {
+		delete(n.networkServiceEndpoint, key)
+	}
+}
+
+// List method lists all known NetworkServiceEndpoint objects.
+func (n *networkServiceEndpointsStore) List() []*netmesh.NetworkServiceEndpoint {
+	n.Lock()
+	defer n.Unlock()
+	networkServiceEndpoints := []*netmesh.NetworkServiceEndpoint{}
+	for _, ns := range n.networkServiceEndpoint {
+		networkServiceEndpoints = append(networkServiceEndpoints, ns)
+	}
+
+	return networkServiceEndpoints
+}

--- a/plugins/objectstore/networkserviceendpoints_test.go
+++ b/plugins/objectstore/networkserviceendpoints_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstore
+
+import (
+	"testing"
+
+	"github.com/ligato/networkservicemesh/netmesh/model/netmesh"
+)
+
+type endpointStore struct {
+	*networkServiceEndpointsStore
+}
+
+const (
+	epTestName      = "EndpointTest"
+	epTestNamespace = "default"
+)
+
+var endpoints *endpointStore
+
+func TestEndpointStore(t *testing.T) {
+	endpoints := &endpointStore{}
+	endpoints.networkServiceEndpointsStore = newNetworkServiceEndpointsStore()
+
+	nse := netmesh.NetworkServiceEndpoint{
+		Metadata: &netmesh.Metadata{},
+	}
+
+	nse = netmesh.NetworkServiceEndpoint{
+		Metadata: &netmesh.Metadata{
+			Name:      epTestName,
+			Namespace: epTestNamespace,
+		},
+	}
+
+	endpoints.networkServiceEndpointsStore.Add(&nse)
+
+	for _, n := range endpoints.networkServiceEndpointsStore.List() {
+		if n.Metadata.Name != epTestName {
+			t.Errorf("Unexpected Name value returned when creating NetworkServiceEndpoint")
+		}
+
+		if n.Metadata.Namespace != epTestNamespace {
+			t.Errorf("Unexpected Namespace value returned when creating NetworkServiceEndpoint")
+		}
+	}
+
+	endpoints.networkServiceEndpointsStore.Delete(meta{name: nse.Metadata.Name, namespace: nse.Metadata.Namespace})
+
+	nseRet := endpoints.networkServiceEndpointsStore.List()
+	if len(nseRet) != 0 {
+		t.Errorf("Deletion of NetworkServiceEndpoint from objectstore failed")
+	}
+}

--- a/plugins/objectstore/networkserviceendpoints_test.go
+++ b/plugins/objectstore/networkserviceendpoints_test.go
@@ -36,10 +36,6 @@ func TestEndpointStore(t *testing.T) {
 	endpoints.networkServiceEndpointsStore = newNetworkServiceEndpointsStore()
 
 	nse := netmesh.NetworkServiceEndpoint{
-		Metadata: &netmesh.Metadata{},
-	}
-
-	nse = netmesh.NetworkServiceEndpoint{
 		Metadata: &netmesh.Metadata{
 			Name:      epTestName,
 			Namespace: epTestNamespace,

--- a/plugins/objectstore/objectstore_api.go
+++ b/plugins/objectstore/objectstore_api.go
@@ -30,4 +30,6 @@ type Interface interface {
 	ObjectCreated(obj interface{})
 	ObjectDeleted(obj interface{})
 	ListNetworkServices() []*netmesh.NetworkService
+	ListNetworkServiceChannels() []*netmesh.NetworkService_NetmeshChannel
+	ListNetworkServiceEndpoints() []*netmesh.NetworkServiceEndpoint
 }

--- a/plugins/objectstore/objectstore_plugin.go
+++ b/plugins/objectstore/objectstore_plugin.go
@@ -29,7 +29,6 @@ type meta struct {
 }
 
 // ObjectStore stores information about all objects learned by CRDs controller
-// TODO add NetworkServiceEndpoint and NetworkServiceChannel
 type objectStore struct {
 	*networkServicesStore
 	*networkServiceChannelsStore
@@ -49,7 +48,6 @@ func newObjectStore() *objectStore {
 	objectStore.networkServicesStore = newNetworkServicesStore()
 	objectStore.networkServiceChannelsStore = newNetworkServiceChannelsStore()
 	objectStore.networkServiceEndpointsStore = newNetworkServiceEndpointsStore()
-	// TODO add initialization of NetworkServiceEndpoint and NetworkServiceChannel
 	return objectStore
 }
 

--- a/plugins/objectstore/objectstore_plugin.go
+++ b/plugins/objectstore/objectstore_plugin.go
@@ -32,6 +32,8 @@ type meta struct {
 // TODO add NetworkServiceEndpoint and NetworkServiceChannel
 type objectStore struct {
 	*networkServicesStore
+	*networkServiceChannelsStore
+	*networkServiceEndpointsStore
 }
 
 // sharedPlugin is used to provide access to ObjectStore to other plugins
@@ -45,6 +47,8 @@ func SharedPlugin() Interface {
 func newObjectStore() *objectStore {
 	objectStore := &objectStore{}
 	objectStore.networkServicesStore = newNetworkServicesStore()
+	objectStore.networkServiceChannelsStore = newNetworkServiceChannelsStore()
+	objectStore.networkServiceEndpointsStore = newNetworkServiceEndpointsStore()
 	// TODO add initialization of NetworkServiceEndpoint and NetworkServiceChannel
 	return objectStore
 }
@@ -102,7 +106,11 @@ func (p *Plugin) ObjectCreated(obj interface{}) {
 		ns := obj.(*v1.NetworkService).Spec
 		p.objects.networkServicesStore.Add(&ns)
 	case *v1.NetworkServiceChannel:
+		nsc := obj.(*v1.NetworkServiceChannel).Spec
+		p.objects.networkServiceChannelsStore.Add(&nsc)
 	case *v1.NetworkServiceEndpoint:
+		nse := obj.(*v1.NetworkServiceEndpoint).Spec
+		p.objects.networkServiceEndpointsStore.Add(&nse)
 	}
 }
 
@@ -110,6 +118,18 @@ func (p *Plugin) ObjectCreated(obj interface{}) {
 func (p *Plugin) ListNetworkServices() []*netmesh.NetworkService {
 	p.Log.Info("ObjectStore.ListNetworkServices.")
 	return p.objects.networkServicesStore.List()
+}
+
+// ListNetworkServiceChannels lists all stored NetworkServiceChannel objects
+func (p *Plugin) ListNetworkServiceChannels() []*netmesh.NetworkService_NetmeshChannel {
+	p.Log.Info("ObjectStore.ListNetworkServiceChannels")
+	return p.objects.networkServiceChannelsStore.List()
+}
+
+// ListNetworkServiceEndpoints lists all stored NetworkServiceEndpoint objects
+func (p *Plugin) ListNetworkServiceEndpoints() []*netmesh.NetworkServiceEndpoint {
+	p.Log.Info("ObjectStore.ListNetworkServiceEndpoints")
+	return p.objects.networkServiceEndpointsStore.List()
 }
 
 // ObjectDeleted is called when an object is deleted
@@ -120,6 +140,10 @@ func (p *Plugin) ObjectDeleted(obj interface{}) {
 		ns := obj.(*v1.NetworkService).Spec
 		p.objects.networkServicesStore.Delete(meta{name: ns.Metadata.Name, namespace: ns.Metadata.Namespace})
 	case *v1.NetworkServiceChannel:
+		nsc := obj.(*v1.NetworkServiceChannel).Spec
+		p.objects.networkServiceChannelsStore.Delete(meta{name: nsc.Metadata.Name, namespace: nsc.Metadata.Namespace})
 	case *v1.NetworkServiceEndpoint:
+		nse := obj.(*v1.NetworkServiceEndpoint).Spec
+		p.objects.networkServiceEndpointsStore.Delete(meta{name: nse.Metadata.Name, namespace: nse.Metadata.Namespace})
 	}
 }


### PR DESCRIPTION
This commit adds an objectstore backend for channels and endpoints,
including Create/Delete/List methods for each as well. The objectstore
will be complete after this commit, and can cache all CRD objects
for NSM clients to utilize.

Signed-off-by: Kyle Mestery <mestery@mestery.com>