### PR TITLE
Remove duplicated code in crd plugin

### DIFF
--- a/flavors/netmesh/netmesh_flavor.go
+++ b/flavors/netmesh/netmesh_flavor.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ligato/cn-infra/flavors/local"
 	"github.com/ligato/cn-infra/flavors/rpc"
 	"github.com/ligato/networkservicemesh/plugins/crd"
-	"github.com/ligato/networkservicemesh/plugins/handler"
 	"github.com/ligato/networkservicemesh/plugins/netmesh"
 	"github.com/ligato/networkservicemesh/plugins/objectstore"
 )
@@ -61,7 +60,6 @@ type FlavorNetmesh struct {
 	// and namespaces.
 	Netmesh     netmesh.Plugin
 	CRD         netmeshplugincrd.Plugin
-	Handler     handler.Plugin
 	ObjectStore objectstore.Plugin
 	injected    bool
 }
@@ -89,9 +87,6 @@ func (f *FlavorNetmesh) Inject() (allReadyInjected bool) {
 	f.Netmesh.StatusMonitor = &f.StatusCheck // StatusCheck included in local.FlavorLocal
 	f.CRD.Deps.PluginInfraDeps = *f.FlavorLocal.InfraDeps("netmeshcrd")
 	f.CRD.Deps.KubeConfig = config.ForPlugin("kube", KubeConfigAdmin, KubeConfigUsage)
-	f.CRD.HandlerAPI = &f.Handler
-	f.Handler.Deps.PluginInfraDeps = *f.FlavorLocal.InfraDeps("netmeshhandler")
-	f.Handler.Deps.KubeConfig = config.ForPlugin("kube", KubeConfigAdmin, KubeConfigUsage)
 
 	// ObjectStore plugin
 	f.ObjectStore.Deps.PluginInfraDeps = *f.FlavorLocal.InfraDeps("objectstore")

--- a/plugins/crd/crd_queue.go
+++ b/plugins/crd/crd_queue.go
@@ -89,7 +89,7 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer
 			// Retrieve the latest version in the cache of this NetworkService. By using
 			// GetByKey() we are able to determine if the item exists, and thus if it was
 			// added or deleted from the queue, and process appropriately
-			item, exists, err := informer.GetIndexer().GetByKey(strKey)
+			item, _, err := informer.GetIndexer().GetByKey(strKey)
 
 			if err != nil {
 				if queue.NumRequeues(key) < QueueRetryCount {
@@ -104,28 +104,19 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer
 			}
 
 			plugin.Log.Infof("Found object of type: %T", reflect.TypeOf(message.(objectMessage).obj))
-
-			// Verify if this was a delete vs. an add/update
-			if !exists {
-				// If the object was deleted, it's no longer in the cache, so we'll use the copy
-				// we made before adding it to our work queue.
-				plugin.Log.Infof("Object (%s) deleted from queue", name)
-				plugin.objectStore.ObjectDeleted(message.(objectMessage).obj)
-			} else {
-				// Check if this is a create or update operation
-				switch message.(objectMessage).operation {
-				case create:
-					// Verify and log if the informer cached version of the object is different than the
-					// copy we made
-					if !reflect.DeepEqual(message.(objectMessage).obj, item) {
-						plugin.Log.Errorf("Informer cached version of object (%s/%s) different than worker queue version", namespace, name)
-					}
-					plugin.Log.Infof("Got most up to date version of '%s/%s'. Syncing...", namespace, name)
-					plugin.objectStore.ObjectCreated(message.(objectMessage).obj)
-				case update:
-					plugin.Log.Infof("Got most up to date version of '%s/%s'. Syncing...", namespace, name)
-					plugin.objectStore.ObjectCreated(message.(objectMessage).obj)
+			// Check if this is a create or delete operation
+			switch message.(objectMessage).operation {
+			case create:
+				// Verify and log if the informer cached version of the object is different than the
+				// copy we made
+				if !reflect.DeepEqual(message.(objectMessage).obj, item) {
+					plugin.Log.Errorf("Informer cached version of object (%s/%s) different than worker queue version", namespace, name)
 				}
+				plugin.Log.Infof("Got most up to date version of '%s/%s'. Syncing...", namespace, name)
+				plugin.objectStore.ObjectCreated(message.(objectMessage).obj)
+			case delete:
+				plugin.Log.Infof("Got most up to date version of '%s/%s'. Syncing...", namespace, name)
+				plugin.objectStore.ObjectDeleted(message.(objectMessage).obj)
 			}
 
 			// As we managed to process this successfully, we can forget it

--- a/plugins/crd/crd_queue.go
+++ b/plugins/crd/crd_queue.go
@@ -110,7 +110,7 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer
 				// If the object was deleted, it's no longer in the cache, so we'll use the copy
 				// we made before adding it to our work queue.
 				plugin.Log.Infof("Object (%s) deleted from queue", name)
-				plugin.HandlerAPI.ObjectDeleted(message.(objectMessage).obj)
+				plugin.objectStore.ObjectDeleted(message.(objectMessage).obj)
 			} else {
 				// Check if this is a create or update operation
 				switch message.(objectMessage).operation {
@@ -121,10 +121,10 @@ func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer
 						plugin.Log.Errorf("Informer cached version of object (%s/%s) different than worker queue version", namespace, name)
 					}
 					plugin.Log.Infof("Got most up to date version of '%s/%s'. Syncing...", namespace, name)
-					plugin.HandlerAPI.ObjectCreated(message.(objectMessage).obj)
+					plugin.objectStore.ObjectCreated(message.(objectMessage).obj)
 				case update:
 					plugin.Log.Infof("Got most up to date version of '%s/%s'. Syncing...", namespace, name)
-					plugin.HandlerAPI.ObjectCreated(message.(objectMessage).obj)
+					plugin.objectStore.ObjectCreated(message.(objectMessage).obj)
 				}
 			}
 

--- a/plugins/crd/crd_utils.go
+++ b/plugins/crd/crd_utils.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// //go:generate protoc -I ./model/pod --go_out=plugins=grpc:./model/pod ./model/pod/pod.proto
+
+package netmeshplugincrd
+
+import (
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// networkServiceValidation generates OpenAPIV3 validator for NetworkService CRD
+func networkServiceValidation() *apiextv1beta1.CustomResourceValidation {
+	maxLength := int64(64)
+	validation := &apiextv1beta1.CustomResourceValidation{
+		OpenAPIV3Schema: &apiextv1beta1.JSONSchemaProps{
+			Properties: map[string]apiextv1beta1.JSONSchemaProps{
+				"spec": {
+					Required: []string{"metadata"},
+					Properties: map[string]apiextv1beta1.JSONSchemaProps{
+						"metadata": {
+							Required: []string{"name"},
+							Properties: map[string]apiextv1beta1.JSONSchemaProps{
+								"name": {
+									Type:        "string",
+									MaxLength:   &maxLength,
+									Description: "NetworkServiceEndpoints Name",
+									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
+								},
+								"namespace": {
+									Type:        "string",
+									MaxLength:   &maxLength,
+									Description: "NetworkServiceEndpoints Namespace",
+									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return validation
+}
+
+// networkServiceEndpointsValidation generates OpenAPIV3 validator for NetworkServiceEndpoints CRD
+func networkServiceEndpointsValidation() *apiextv1beta1.CustomResourceValidation {
+	maxLength := int64(64)
+	validation := &apiextv1beta1.CustomResourceValidation{
+		OpenAPIV3Schema: &apiextv1beta1.JSONSchemaProps{
+			Properties: map[string]apiextv1beta1.JSONSchemaProps{
+				"spec": {
+					Required: []string{"metadata"},
+					Properties: map[string]apiextv1beta1.JSONSchemaProps{
+						"metadata": {
+							Required: []string{"name"},
+							Properties: map[string]apiextv1beta1.JSONSchemaProps{
+								"name": {
+									Type:        "string",
+									MaxLength:   &maxLength,
+									Description: "NetworkServiceEndpoints Name",
+									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
+								},
+								"namespace": {
+									Type:        "string",
+									MaxLength:   &maxLength,
+									Description: "NetworkServiceEndpoints Namespace",
+									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return validation
+}
+
+// networkServiceChannels generates OpenAPIV3 validator for NetworkServiceChannels CRD
+func networkServiceChannelsValidation() *apiextv1beta1.CustomResourceValidation {
+	maxLength := int64(64)
+	validation := &apiextv1beta1.CustomResourceValidation{
+		OpenAPIV3Schema: &apiextv1beta1.JSONSchemaProps{
+			Properties: map[string]apiextv1beta1.JSONSchemaProps{
+				"spec": {
+					Required: []string{"metadata"},
+					Properties: map[string]apiextv1beta1.JSONSchemaProps{
+						"metadata": {
+							Required: []string{"name"},
+							Properties: map[string]apiextv1beta1.JSONSchemaProps{
+								"name": {
+									Type:        "string",
+									MaxLength:   &maxLength,
+									Description: "NetworkServiceEndpoints Name",
+									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
+								},
+								"namespace": {
+									Type:        "string",
+									MaxLength:   &maxLength,
+									Description: "NetworkServiceEndpoints Namespace",
+									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return validation
+}
+
+// Create the CRD resource, ignore error if it already exists
+func createCRD(plugin *Plugin, FullName, Group, Version, Plural, Name string) error {
+
+	var validation *apiextv1beta1.CustomResourceValidation
+	switch Name {
+	case "NetworkService":
+		validation = networkServiceValidation()
+	case "NetworkServiceEndpoints":
+		validation = networkServiceEndpointsValidation()
+	case "NetworkServiceChannels":
+		validation = networkServiceChannelsValidation()
+	default:
+		validation = &apiextv1beta1.CustomResourceValidation{}
+	}
+	crd := &apiextv1beta1.CustomResourceDefinition{
+		ObjectMeta: meta.ObjectMeta{Name: FullName},
+		Spec: apiextv1beta1.CustomResourceDefinitionSpec{
+			Group:   Group,
+			Version: Version,
+			Scope:   apiextv1beta1.NamespaceScoped,
+			Names: apiextv1beta1.CustomResourceDefinitionNames{
+				Plural: Plural,
+				Kind:   Name,
+			},
+			Validation: validation,
+		},
+	}
+	_, cserr := plugin.apiclientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+	if apierrors.IsAlreadyExists(cserr) {
+		return nil
+	}
+
+	return cserr
+}

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -22,10 +22,7 @@ import (
 	"sync"
 	"time"
 
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -39,6 +36,7 @@ import (
 	client "github.com/ligato/networkservicemesh/pkg/client/clientset/versioned"
 	factory "github.com/ligato/networkservicemesh/pkg/client/informers/externalversions"
 	"github.com/ligato/networkservicemesh/plugins/handler"
+	"k8s.io/client-go/util/workqueue"
 )
 
 // Plugin watches K8s resources and causes all changes to be reflected in the ETCD
@@ -105,147 +103,9 @@ func (plugin *Plugin) Init() error {
 	return nil
 }
 
-// networkServiceValidation generates OpenAPIV3 validator for NetworkService CRD
-func networkServiceValidation() *apiextv1beta1.CustomResourceValidation {
-	maxLength := int64(64)
-	validation := &apiextv1beta1.CustomResourceValidation{
-		OpenAPIV3Schema: &apiextv1beta1.JSONSchemaProps{
-			Properties: map[string]apiextv1beta1.JSONSchemaProps{
-				"spec": {
-					Required: []string{"metadata"},
-					Properties: map[string]apiextv1beta1.JSONSchemaProps{
-						"metadata": {
-							Required: []string{"name"},
-							Properties: map[string]apiextv1beta1.JSONSchemaProps{
-								"name": {
-									Type:        "string",
-									MaxLength:   &maxLength,
-									Description: "NetworkServiceEndpoints Name",
-									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
-								},
-								"namespace": {
-									Type:        "string",
-									MaxLength:   &maxLength,
-									Description: "NetworkServiceEndpoints Namespace",
-									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	return validation
-}
-
-// networkServiceEndpointsValidation generates OpenAPIV3 validator for NetworkServiceEndpoints CRD
-func networkServiceEndpointsValidation() *apiextv1beta1.CustomResourceValidation {
-	maxLength := int64(64)
-	validation := &apiextv1beta1.CustomResourceValidation{
-		OpenAPIV3Schema: &apiextv1beta1.JSONSchemaProps{
-			Properties: map[string]apiextv1beta1.JSONSchemaProps{
-				"spec": {
-					Required: []string{"metadata"},
-					Properties: map[string]apiextv1beta1.JSONSchemaProps{
-						"metadata": {
-							Required: []string{"name"},
-							Properties: map[string]apiextv1beta1.JSONSchemaProps{
-								"name": {
-									Type:        "string",
-									MaxLength:   &maxLength,
-									Description: "NetworkServiceEndpoints Name",
-									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
-								},
-								"namespace": {
-									Type:        "string",
-									MaxLength:   &maxLength,
-									Description: "NetworkServiceEndpoints Namespace",
-									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	return validation
-}
-
-// networkServiceChannels generates OpenAPIV3 validator for NetworkServiceChannels CRD
-func networkServiceChannelsValidation() *apiextv1beta1.CustomResourceValidation {
-	maxLength := int64(64)
-	validation := &apiextv1beta1.CustomResourceValidation{
-		OpenAPIV3Schema: &apiextv1beta1.JSONSchemaProps{
-			Properties: map[string]apiextv1beta1.JSONSchemaProps{
-				"spec": {
-					Required: []string{"metadata"},
-					Properties: map[string]apiextv1beta1.JSONSchemaProps{
-						"metadata": {
-							Required: []string{"name"},
-							Properties: map[string]apiextv1beta1.JSONSchemaProps{
-								"name": {
-									Type:        "string",
-									MaxLength:   &maxLength,
-									Description: "NetworkServiceEndpoints Name",
-									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
-								},
-								"namespace": {
-									Type:        "string",
-									MaxLength:   &maxLength,
-									Description: "NetworkServiceEndpoints Namespace",
-									Pattern:     `^[a-zA-Z0-9]+[\-a-zA-Z0-9]*$`,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	return validation
-}
-
-// Create the CRD resource, ignore error if it already exists
-func createCRD(plugin *Plugin, FullName, Group, Version, Plural, Name string) error {
-
-	var validation *apiextv1beta1.CustomResourceValidation
-	switch Name {
-	case "NetworkService":
-		validation = networkServiceValidation()
-	case "NetworkServiceEndpoints":
-		validation = networkServiceEndpointsValidation()
-	case "NetworkServiceChannels":
-		validation = networkServiceChannelsValidation()
-	default:
-		validation = &apiextv1beta1.CustomResourceValidation{}
-	}
-	crd := &apiextv1beta1.CustomResourceDefinition{
-		ObjectMeta: meta.ObjectMeta{Name: FullName},
-		Spec: apiextv1beta1.CustomResourceDefinitionSpec{
-			Group:   Group,
-			Version: Version,
-			Scope:   apiextv1beta1.NamespaceScoped,
-			Names: apiextv1beta1.CustomResourceDefinitionNames{
-				Plural: Plural,
-				Kind:   Name,
-			},
-			Validation: validation,
-		},
-	}
-	_, cserr := plugin.apiclientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
-	if apierrors.IsAlreadyExists(cserr) {
-		return nil
-	}
-
-	return cserr
-}
-
-func informerNetworkServices(plugin *Plugin) {
-	plugin.informerNS = plugin.sharedFactory.Networkservice().V1().NetworkServices().Informer()
+func setupInformer(informer cache.SharedIndexInformer, queue workqueue.RateLimitingInterface) {
 	// We add a new event handler, watching for changes to API resources.
-	plugin.informerNS.AddEventHandler(
+	informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				var message objectMessage
@@ -254,7 +114,7 @@ func informerNetworkServices(plugin *Plugin) {
 				message.operation = create
 				message.obj = obj
 				if err == nil {
-					queueNS.Add(message)
+					queue.Add(message)
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {
@@ -266,13 +126,13 @@ func informerNetworkServices(plugin *Plugin) {
 					messageOld.operation = delete
 					messageOld.obj = old
 					if err == nil {
-						queueNS.Add(messageOld)
+						queue.Add(messageOld)
 					}
 					messageCur.key, err = cache.MetaNamespaceKeyFunc(cur)
 					messageCur.operation = create
 					messageCur.obj = cur
 					if err == nil {
-						queueNS.Add(messageCur)
+						queue.Add(messageCur)
 					}
 				}
 			},
@@ -283,103 +143,7 @@ func informerNetworkServices(plugin *Plugin) {
 				message.operation = delete
 				message.obj = obj
 				if err == nil {
-					queueNS.Add(message)
-				}
-			},
-		},
-	)
-}
-
-func informerNetworkServiceChannels(plugin *Plugin) {
-	plugin.informerNSC = plugin.sharedFactory.Networkservice().V1().NetworkServiceChannels().Informer()
-	// we add a new event handler, watching for changes to API resources.
-	plugin.informerNSC.AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				var message objectMessage
-				var err error
-				message.key, err = cache.MetaNamespaceKeyFunc(obj)
-				message.operation = create
-				message.obj = obj
-				if err == nil {
-					queueNSC.Add(message)
-				}
-			},
-			UpdateFunc: func(old, cur interface{}) {
-				if !reflect.DeepEqual(old, cur) {
-					// For an update event, we delete the old and add the current
-					var messageOld, messageCur objectMessage
-					var err error
-					messageOld.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-					messageOld.operation = delete
-					messageOld.obj = old
-					if err == nil {
-						queueNSC.Add(messageOld)
-					}
-					messageCur.key, err = cache.MetaNamespaceKeyFunc(cur)
-					messageCur.operation = create
-					messageCur.obj = cur
-					if err == nil {
-						queueNSC.Add(messageCur)
-					}
-				}
-			},
-			DeleteFunc: func(obj interface{}) {
-				var message objectMessage
-				var err error
-				message.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				message.operation = delete
-				message.obj = obj
-				if err == nil {
-					queueNSC.Add(message)
-				}
-			},
-		},
-	)
-}
-
-func informerNetworkServiceEndpoints(plugin *Plugin) {
-	plugin.informerNSE = plugin.sharedFactory.Networkservice().V1().NetworkServiceEndpoints().Informer()
-	// we add a new event handler, watching for changes to API resources.
-	plugin.informerNSE.AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				var message objectMessage
-				var err error
-				message.key, err = cache.MetaNamespaceKeyFunc(obj)
-				message.operation = create
-				message.obj = obj
-				if err == nil {
-					queueNSE.Add(message)
-				}
-			},
-			UpdateFunc: func(old, cur interface{}) {
-				if !reflect.DeepEqual(old, cur) {
-					// For an update event, we delete the old and add the current
-					var messageOld, messageCur objectMessage
-					var err error
-					messageOld.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(old)
-					messageOld.operation = delete
-					messageOld.obj = old
-					if err == nil {
-						queueNSE.Add(messageOld)
-					}
-					messageCur.key, err = cache.MetaNamespaceKeyFunc(cur)
-					messageCur.operation = create
-					messageCur.obj = cur
-					if err == nil {
-						queueNSE.Add(messageCur)
-					}
-				}
-			},
-			DeleteFunc: func(obj interface{}) {
-				var message objectMessage
-				var err error
-				message.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				message.operation = delete
-				message.obj = obj
-				if err == nil {
-					queueNSE.Add(message)
+					queue.Add(message)
 				}
 			},
 		},
@@ -446,9 +210,12 @@ func (plugin *Plugin) AfterInit() error {
 	// create/replace/update/delete operations are missed when watching
 	plugin.sharedFactory = factory.NewSharedInformerFactory(plugin.crdClient, time.Second*30)
 
-	informerNetworkServices(plugin)
-	informerNetworkServiceChannels(plugin)
-	informerNetworkServiceEndpoints(plugin)
+	plugin.informerNS = plugin.sharedFactory.Networkservice().V1().NetworkServices().Informer()
+	setupInformer(plugin.informerNS, queueNS)
+	plugin.informerNSC = plugin.sharedFactory.Networkservice().V1().NetworkServiceChannels().Informer()
+	setupInformer(plugin.informerNSC, queueNSC)
+	plugin.informerNSE = plugin.sharedFactory.Networkservice().V1().NetworkServiceEndpoints().Informer()
+	setupInformer(plugin.informerNSE, queueNSE)
 
 	// Start the informer. This will cause it to begin receiving updates from
 	// the configured API server and firing event handlers in response.

--- a/plugins/handler/plugin_impl_handler.go
+++ b/plugins/handler/plugin_impl_handler.go
@@ -71,11 +71,14 @@ func (p *Plugin) AfterInit() error {
 	p.Log.Info("AfterInit")
 
 	ticker := time.NewTicker(objectstore.ObjectStoreReadyInterval)
+	timeout := time.After(time.Second * 60)
 	defer ticker.Stop()
 	// Wait for objectstore to initialize
 	ready := false
 	for !ready {
 		select {
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for ObjectStore")
 		case <-ticker.C:
 			if p.objectStore = objectstore.SharedPlugin(); p.objectStore != nil {
 				ready = true


### PR DESCRIPTION
Removing duplicated code in setting up informers and moving non controller related code into crd_utils.go

Also closes: #137 

Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>