### PR TITLE
Add a Makefile to ease building Network Service Mesh code and images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,7 @@ before_script:
 - sudo mount --make-rshared /
 
 script:
-- shellcheck $(find . -name "*.sh" -not -path "./vendor/*")
-- ./scripts/verify-codegen.sh
-- docker build -t ligato/networkservicemesh/netmesh-test -f build/nsm/docker/Test.Dockerfile .
-- docker build -t ligato/networkservicemesh/netmesh -f build/nsm/docker/Dockerfile .
-- docker build -t ligato/networkservicemesh/nsm-init -f build/nsm-init/docker/Dockerfile .
-- docker build -t ligato/networkservicemesh/nse -f build/nse/docker/Dockerfile .
+- make all
 - ./scripts/travis-integration-tests.sh minikube
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+GOCMD=go
+GOFMT=${GOCMD} fmt
+GOGET=${GOCMD} get
+GOGENERATE=${GOCMD} generate
+GOINSTALL=${GOCMD} install
+GOTEST=${GOCMD} test
+
+#
+# The all target is what is used by the travis-ci system to build the Docker images
+# which are used to run the code in each run.
+#
 all: check verify docker-build
 
 check:
@@ -26,3 +37,23 @@ docker-build:
 	@docker build -t ligato/networkservicemesh/nsm-init -f build/nsm-init/docker/Dockerfile .
 	@docker build -t ligato/networkservicemesh/nse -f build/nse/docker/Dockerfile .
 
+#
+# The following targets are meant to be run when working with the code locally.
+#
+format:
+	@${GOFMT} ./...
+
+deps:
+	@${GOGET} -u github.com/golang/protobuf/protoc-gen-go
+
+generate:
+	@${GOGENERATE} ./...
+
+install:
+	@${GOINSTALL} ./...
+
+test:
+	@${GOTEST} ./... -cover
+
+test-race:
+	@${GOTEST} -race ./... -cover

--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,5 @@ docker-build:
 	@docker build -t ligato/networkservicemesh/netmesh-test -f build/nsm/docker/Test.Dockerfile .
 	@docker build -t ligato/networkservicemesh/netmesh -f build/nsm/docker/Dockerfile .
 	@docker build -t ligato/networkservicemesh/nsm-init -f build/nsm-init/docker/Dockerfile .
+	@docker build -t ligato/networkservicemesh/nse -f build/nse/docker/Dockerfile .
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+GOPATH?=$(shell go env GOPATH)
 GOCMD=go
 GOFMT=${GOCMD} fmt
 GOGET=${GOCMD} get
@@ -19,6 +20,7 @@ GOGENERATE=${GOCMD} generate
 GOINSTALL=${GOCMD} install
 GOTEST=${GOCMD} test
 
+.PHONY: all check verify docker-build
 #
 # The all target is what is used by the travis-ci system to build the Docker images
 # which are used to run the code in each run.
@@ -37,6 +39,7 @@ docker-build:
 	@docker build -t ligato/networkservicemesh/nsm-init -f build/nsm-init/docker/Dockerfile .
 	@docker build -t ligato/networkservicemesh/nse -f build/nse/docker/Dockerfile .
 
+.PHONY: format deps generate install test test-race
 #
 # The following targets are meant to be run when working with the code locally.
 #

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# Copyright (c) 2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: check verify docker-build
+
+check:
+	@shellcheck `find . -name "*.sh" -not -path "./vendor/*"`
+
+verify:
+	@./scripts/verify-codegen.sh
+
+docker-build:
+	@docker build -t ligato/networkservicemesh/netmesh-test -f build/nsm/docker/Test.Dockerfile .
+	@docker build -t ligato/networkservicemesh/netmesh -f build/nsm/docker/Dockerfile .
+	@docker build -t ligato/networkservicemesh/nsm-init -f build/nsm-init/docker/Dockerfile .
+

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ GOGET=${GOCMD} get
 GOGENERATE=${GOCMD} generate
 GOINSTALL=${GOCMD} install
 GOTEST=${GOCMD} test
+GOVET=${GOCMD} tool vet
+GOVETTARGETS=cmd \
+	pkg/apis/networkservicemesh.io/v1 \
+	pkg/nsm \
+	plugins \
+	utils
 
 .PHONY: all check verify docker-build
 #
@@ -33,13 +39,25 @@ check:
 verify:
 	@./scripts/verify-codegen.sh
 
-docker-build:
+docker-build: docker-build-netmesh-test docker-build-netmesh docker-build-nsm-init docker-build-nse
+
+.PHONY: docker-build-netmesh-test
+docker-build-netmesh-test:
 	@docker build -t ligato/networkservicemesh/netmesh-test -f build/nsm/docker/Test.Dockerfile .
+
+.PHONY: docker-build-netmesh
+docker-build-netmesh:
 	@docker build -t ligato/networkservicemesh/netmesh -f build/nsm/docker/Dockerfile .
+
+.PHONY: docker-build-nsm-init
+docker-build-nsm-init:
 	@docker build -t ligato/networkservicemesh/nsm-init -f build/nsm-init/docker/Dockerfile .
+
+.PHONY: docker-build-nse
+docker-build-nse:
 	@docker build -t ligato/networkservicemesh/nse -f build/nse/docker/Dockerfile .
 
-.PHONY: format deps generate install test test-race
+.PHONY: format deps generate install test test-race vet
 #
 # The following targets are meant to be run when working with the code locally.
 #
@@ -60,3 +78,6 @@ test:
 
 test-race:
 	@${GOTEST} -race ./... -cover
+
+vet:
+	${GOVET} ${GOVETTARGETS}


### PR DESCRIPTION
The following Makefile targets are defined:

* verify
* check
* docker-build

The idea is the ensure we run the same build commands in the Makefile as are
executed in the Travis CI builds. This simplifies the process of building
Network Service Mesh code and images for first time users.

Signed-off-by: Kyle Mestery <mestery@mestery.com>