### PR TITLE
Add proxy support to docker build commands in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,6 @@ endif
 
 DOCKERBUILD=docker build ${HTTPBUILD} ${HTTPSBUILD}
 
-# Test target to debug proxy issues
-checkproxy:
-	echo "HTTPBUILD=${HTTPBUILD} HTTPSBUILD=${HTTPSBUILD}"
-	echo "DOCKERBUILD=${DOCKERBUILD}"
-
 .PHONY: all check verify docker-build
 #
 # The all target is what is used by the travis-ci system to build the Docker images
@@ -100,3 +95,8 @@ test-race:
 
 vet:
 	${GOVET} ${GOVETTARGETS}
+
+# Test target to debug proxy issues
+checkproxy:
+	echo "HTTPBUILD=${HTTPBUILD} HTTPSBUILD=${HTTPSBUILD}"
+	echo "DOCKERBUILD=${DOCKERBUILD}"

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,25 @@ GOVETTARGETS=cmd \
 	plugins \
 	utils
 
+# Setup proxies for docker build
+ifeq ($(HTTP_PROXY),)
+HTTPBUILD=
+else
+HTTPBUILD=--build-arg HTTP_PROXY=$(HTTP_PROXY)
+endif
+ifeq ($(HTTPS_PROXY),)
+HTTPSBUILD=
+else
+HTTPSBUILD=--build-arg HTTPS_PROXY=$(HTTPS_PROXY)
+endif
+
+DOCKERBUILD=docker build ${HTTPBUILD} ${HTTPSBUILD}
+
+# Test target to debug proxy issues
+checkproxy:
+	echo "HTTPBUILD=${HTTPBUILD} HTTPSBUILD=${HTTPSBUILD}"
+	echo "DOCKERBUILD=${DOCKERBUILD}"
+
 .PHONY: all check verify docker-build
 #
 # The all target is what is used by the travis-ci system to build the Docker images
@@ -43,19 +62,19 @@ docker-build: docker-build-netmesh-test docker-build-netmesh docker-build-nsm-in
 
 .PHONY: docker-build-netmesh-test
 docker-build-netmesh-test:
-	@docker build -t ligato/networkservicemesh/netmesh-test -f build/nsm/docker/Test.Dockerfile .
+	${DOCKERBUILD} -t ligato/networkservicemesh/netmesh-test -f build/nsm/docker/Test.Dockerfile .
 
 .PHONY: docker-build-netmesh
 docker-build-netmesh:
-	@docker build -t ligato/networkservicemesh/netmesh -f build/nsm/docker/Dockerfile .
+	${DOCKERBUILD} -t ligato/networkservicemesh/netmesh -f build/nsm/docker/Dockerfile .
 
 .PHONY: docker-build-nsm-init
 docker-build-nsm-init:
-	@docker build -t ligato/networkservicemesh/nsm-init -f build/nsm-init/docker/Dockerfile .
+	${DOCKERBUILD} -t ligato/networkservicemesh/nsm-init -f build/nsm-init/docker/Dockerfile .
 
 .PHONY: docker-build-nse
 docker-build-nse:
-	@docker build -t ligato/networkservicemesh/nse -f build/nse/docker/Dockerfile .
+	${DOCKERBUILD} -t ligato/networkservicemesh/nse -f build/nse/docker/Dockerfile .
 
 .PHONY: format deps generate install test test-race vet
 #

--- a/build/nsm/docker/Test.Dockerfile
+++ b/build/nsm/docker/Test.Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:1 as build
 ENV PACKAGEPATH=github.com/ligato/networkservicemesh/
 
+ENV http_proxy ${HTTP_PROXY}
+ENV https_proxy ${HTTPS_PROXY}
 RUN apt update
 RUN apt install -y git bash unzip
-RUN wget https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
+RUN wget -e use_proxy=yes https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
 RUN unzip -d /usr/local protoc-3.5.1-linux-x86_64
 COPY [".","/go/src/${PACKAGEPATH}"]
 WORKDIR /go/src/${PACKAGEPATH}/


### PR DESCRIPTION
When trying to use the Makefile to build on a machine behind a proxy, it
was observed the docker build commands all failed. This commit adds support
for using a proxy with the docker build commands in the Makefile. It also
fixes an explicit usage of "wget" in the nsm Test.Dockerfile to use a proxy.

Signed-off-by: Kyle Mestery <mestery@mestery.com>