### PR TITLE
Indicate a user should install shellcheck before building

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -10,7 +10,7 @@ You will need to install
 ## On a Mac:
 
 ```bash
-brew install golang protobuf dep
+brew install golang protobuf dep shellcheck
 go get -u github.com/golang/protobuf/protoc-gen-go
 ```
 


### PR DESCRIPTION
Without spellcheck, a `make check` or even a simple `make` will fail.

Signed-off-by: Kyle Mestery <mestery@mestery.com>