### PR TITLE
Fix bug in depstools.Check()

### DIFF
--- a/utils/helper/deptools/check.go
+++ b/utils/helper/deptools/check.go
@@ -58,7 +58,7 @@ func check(structField *reflect.StructField, value *reflect.Value) error {
 		tag, ok := sf.Tag.Lookup(optionalTagName)
 		if (!ok || tag != optionalTagValue) && v.CanInterface() {
 			field := v.Interface()
-			zeroValue := reflect.Zero(v.Type())
+			zeroValue := reflect.Zero(v.Type()).Interface()
 			if field == nil || field == zeroValue {
 				return fmt.Errorf("field in Deps struct named %s is zero valued, and lacks tag `optional:\"true\"`.  Please either set it to a non-zero value or add the `optional:\"true\"` to indicate its acceptable for it to be zero valued", sf.Name)
 			}

--- a/utils/helper/deptools/check_test.go
+++ b/utils/helper/deptools/check_test.go
@@ -128,3 +128,18 @@ func TestCheck(t *testing.T) {
 	}
 	Expect(deptools.Check(p)).To(Succeed())
 }
+
+type DepsWithName struct {
+	Name string
+}
+
+type PluginDepsWithName struct {
+	id1.Impl
+	Deps DepsWithName
+}
+
+func TestCheckDepsWithName(t *testing.T) {
+	RegisterTestingT(t)
+	p := &PluginDepsWithName{}
+	Expect(deptools.Check(p)).ToNot(Succeed())
+}

--- a/utils/registry/api.go
+++ b/utils/registry/api.go
@@ -1,0 +1,28 @@
+// Copyright 2018 Red Hat, Inc.
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package core manages the lifecycle of all plugins (start, graceful
+// shutdown) and defines the core lifecycle SPI. The core lifecycle SPI
+// must be implemented by each plugin.
+
+package registry
+
+import "github.com/ligato/networkservicemesh/plugins/idempotent"
+
+// API - Registry API
+type API interface {
+	LoadOrStore(p idempotent.PluginAPI) idempotent.PluginAPI
+	Delete(p idempotent.PluginAPI)
+}

--- a/utils/registry/doc.go
+++ b/utils/registry/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2018 Red Hat, Inc.
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package core manages the lifecycle of all plugins (start, graceful
+// shutdown) and defines the core lifecycle SPI. The core lifecycle SPI
+// must be implemented by each plugin.
+
+package registry

--- a/utils/registry/registry.go
+++ b/utils/registry/registry.go
@@ -1,0 +1,98 @@
+// Copyright 2018 Red Hat, Inc.
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package core manages the lifecycle of all plugins (start, graceful
+// shutdown) and defines the core lifecycle SPI. The core lifecycle SPI
+// must be implemented by each plugin.
+
+package registry
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/ligato/networkservicemesh/plugins/idempotent"
+	"github.com/ligato/networkservicemesh/utils/helper/deptools"
+)
+
+// Impl - implementation of a Registry
+type Impl struct {
+	plugins []idempotent.PluginAPI
+	sync.Mutex
+}
+
+// LoadOrStore - return a plugin with Deps matching p.Deps if in registry
+// or store p in the registry and return p if not
+func (r *Impl) LoadOrStore(p idempotent.PluginAPI) idempotent.PluginAPI {
+	r.Lock()
+	defer r.Unlock()
+	for _, value := range r.plugins {
+		vdeps, _ := deptools.Get(value)
+		pdeps, _ := deptools.Get(p)
+		if reflect.TypeOf(value) == reflect.TypeOf(p) && reflect.DeepEqual(pdeps, vdeps) {
+			return value
+		}
+	}
+	r.plugins = append(r.plugins, p)
+	return p
+}
+
+// Delete - delete p from registry
+func (r *Impl) Delete(p idempotent.PluginAPI) {
+	r.Lock()
+	defer r.Unlock()
+	for i, value := range r.plugins {
+		vdeps, _ := deptools.Get(value)
+		pdeps, _ := deptools.Get(p)
+		if reflect.TypeOf(value) == reflect.TypeOf(p) && reflect.DeepEqual(pdeps, vdeps) {
+			r.plugins = append(r.plugins[:i], r.plugins[i+1:]...)
+			return
+		}
+	}
+}
+
+// Size - number of plugins in registry
+func (r *Impl) Size() int {
+	return len(r.plugins)
+}
+
+var registry *Impl
+var once sync.Once
+
+// Shared - Return the Shared registry
+func Shared() *Impl {
+	once.Do(func() { registry = New() })
+	return registry
+}
+
+// New - return a new registry
+func New() *Impl {
+	return &Impl{}
+}
+
+// Testable - Wrapper around Impl - only for use in testing
+type Testable struct {
+	*Impl
+}
+
+// Clear is intended only for testing - only for use in testing
+func (r *Testable) Clear() {
+	r.plugins = nil
+}
+
+// WrapTestable - Wrap Impl in Testable - only for use in testing
+func WrapTestable(i *Impl) *Testable {
+	return &Testable{Impl: i}
+}

--- a/utils/registry/registry_test.go
+++ b/utils/registry/registry_test.go
@@ -1,0 +1,183 @@
+// Copyright 2018 Red Hat, Inc.
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package core manages the lifecycle of all plugins (start, graceful
+// shutdown) and defines the core lifecycle SPI. The core lifecycle SPI
+// must be implemented by each plugin.
+
+package registry_test
+
+import (
+	"reflect"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/ligato/networkservicemesh/plugins/idempotent"
+	"github.com/ligato/networkservicemesh/utils/helper/deptools"
+	id1 "github.com/ligato/networkservicemesh/utils/idempotent"
+	"github.com/ligato/networkservicemesh/utils/registry"
+)
+
+type Deps struct {
+	Bool bool
+}
+
+type Plugin struct {
+	id1.Impl
+	Deps
+}
+
+func (p *Plugin) Close() error { registry.Shared().Delete(p); return nil }
+
+type PluginNoDeps struct {
+	id1.Impl
+}
+
+func (p *PluginNoDeps) Close() error { registry.Shared().Delete(p); return nil }
+
+func TestRegistryReuse(t *testing.T) {
+	RegisterTestingT(t)
+	p1 := &Plugin{}
+	p2 := &Plugin{}
+	SuiteRegistryReuse(t, p1, p2)
+}
+
+func TestRegistryDeleteOnClose(t *testing.T) {
+	RegisterTestingT(t)
+	p1 := &Plugin{}
+	p2 := &Plugin{}
+	SuiteRegistryDeleteOnClose(t, p1, p2)
+}
+
+func TestRegistryUnequalPlugins(t *testing.T) {
+	RegisterTestingT(t)
+	p1 := &Plugin{}
+	p2 := &Plugin{
+		Deps: Deps{
+			Bool: true,
+		},
+	}
+	SuiteRegistryUnequalPlugins(t, p1, p2)
+}
+
+func TestRegistry(t *testing.T) {
+	RegisterTestingT(t)
+	p1 := &Plugin{}
+	p2 := &Plugin{}
+	p3 := &Plugin{
+		Deps: Deps{
+			Bool: true,
+		},
+	}
+	SuiteRegistry(t, p1, p2, p3)
+}
+
+func TestRegistryNoDeps(t *testing.T) {
+	RegisterTestingT(t)
+	p1 := &Plugin{}
+	p2 := &Plugin{}
+	SuiteRegistryNoDeps(t, p1, p2)
+}
+
+// SuiteRegistry
+// t = *testing.T
+// p1, p2 - Two Plugins that are *not* identical, but should have the same Deps values
+// p3 - A Plugin with different Dep values than p1 or p2
+func SuiteRegistry(t *testing.T, p1 idempotent.PluginAPI, p2 idempotent.PluginAPI, p3 idempotent.PluginAPI) {
+	RegisterTestingT(t)
+	SuiteRegistryReuse(t, p1, p2)
+	SuiteRegistryUnequalPlugins(t, p1, p3)
+	SuiteRegistryDeleteOnClose(t, p1, p2)
+}
+
+// SuiteRegistryNoDeps - A Registry Suite to use for Plugins with NoDeps
+// t = *testing.T
+// p1, p2 - Two Plugins that are *not* identical, but should have the same Deps values
+func SuiteRegistryNoDeps(t *testing.T, p1 idempotent.PluginAPI, p2 idempotent.PluginAPI) {
+	RegisterTestingT(t)
+	SuiteRegistryReuse(t, p1, p2)
+	SuiteRegistryDeleteOnClose(t, p1, p2)
+}
+
+// SuiteRegistryReuse
+// t = *testing.T
+// p1, p2 - Two Plugins that are *not* identical, but should have the same Deps values
+func SuiteRegistryReuse(t *testing.T, p1 idempotent.PluginAPI, p2 idempotent.PluginAPI) {
+	RegisterTestingT(t)
+	r := registry.New()
+	Expect(r.Size()).To(Equal(0), "Expected Empty Registry")
+	Expect(p1 == p2).To(BeFalse(), "p1 == p2, p1 and p2 cannot be identical for this test")
+	Expect(reflect.TypeOf(p1) == reflect.TypeOf(p2)).To(BeTrue(), "p1 and p2 are not of the same type")
+	deps1, err := deptools.Get(p1)
+	Expect(err).To(Succeed())
+	deps2, err := deptools.Get(p2)
+	Expect(err).To(Succeed())
+	Expect(reflect.DeepEqual(deps1, deps2)).To(BeTrue(), "p1.Deps and p2.Deps are not deeply equal")
+	r.LoadOrStore(p1)
+	Expect(r.Size()).To(Equal(1), "Expected Registry to have 1 elements")
+	p3 := r.LoadOrStore(p2)
+	Expect(r.Size()).To(Equal(1), "Expected Registry to have 1 elements")
+	Expect(p1 == p3).To(BeTrue())
+	Expect(p2 == p3).To(BeFalse())
+}
+
+// SuiteRegistryDeleteOnClose
+// t = *testing.T
+// p1, p2 - Two Plugins that are *not* identical, but should have the same Deps values
+func SuiteRegistryDeleteOnClose(t *testing.T, p1 idempotent.PluginAPI, p2 idempotent.PluginAPI) {
+	RegisterTestingT(t)
+	r := registry.Shared()
+	registry.WrapTestable(r).Clear()
+	Expect(r.Size()).To(Equal(0), "Expected Empty Registry")
+	Expect(p1 == p2).To(BeFalse())
+	Expect(reflect.TypeOf(p1) == reflect.TypeOf(p2)).To(BeTrue())
+	deps1, err := deptools.Get(p1)
+	Expect(err).To(Succeed())
+	deps2, err := deptools.Get(p2)
+	Expect(err).To(Succeed())
+	Expect(reflect.DeepEqual(deps1, deps2)).To(BeTrue(), "p1.Deps and p2.Deps are not deeply equal")
+	r.LoadOrStore(p1)
+	Expect(r.Size()).To(Equal(1), "Expected Registry to have 1 elements")
+	Expect(p1.Init()).To(Succeed())
+	Expect(p1.Close()).To(Succeed())
+	Expect(r.Size()).To(Equal(0), "Expected Empty Registry")
+	p3 := r.LoadOrStore(p2)
+	Expect(r.Size()).To(Equal(1))
+	Expect(p1 == p3).To(BeFalse())
+	Expect(p2 == p3).To(BeTrue())
+}
+
+// SuiteRegistryUnequalPlugins
+// t = *testing.T
+// p1, p2 - Two Plugins that have different Deps value
+func SuiteRegistryUnequalPlugins(t *testing.T, p1 idempotent.PluginAPI, p2 idempotent.PluginAPI) {
+	RegisterTestingT(t)
+	registry := registry.New()
+	Expect(registry.Size()).To(Equal(0), "Expected Empty Registry")
+	Expect(p1 == p2).To(BeFalse())
+	Expect(reflect.TypeOf(p1) == reflect.TypeOf(p2)).To(BeTrue())
+	deps1, err := deptools.Get(p1)
+	Expect(err).To(Succeed())
+	deps2, err := deptools.Get(p2)
+	Expect(err).To(Succeed())
+	Expect(reflect.DeepEqual(deps1, deps2)).To(BeFalse(), "p1.Deps and p2.Deps must not be deeply equal for this test")
+	registry.LoadOrStore(p1)
+	Expect(registry.Size()).To(Equal(1), "Expected Registry to have 1 element")
+	p3 := registry.LoadOrStore(p2)
+	Expect(registry.Size()).To(Equal(2), "Expected Registry to have 1 element")
+	Expect(p1 == p3).To(BeFalse())
+	Expect(p2 == p3).To(BeTrue())
+}


### PR DESCRIPTION
deptools.Check() was failing on testing for zero valued simple values
like string "".

This PR fixes that, and adds a test to catch the bug in the future.