### PR TITLE
Adding a controller to watch for pod  delete event (control plane clean up fir NSE)

### DIFF
--- a/conf/sample/networkservice-daemonset.yaml
+++ b/conf/sample/networkservice-daemonset.yaml
@@ -42,10 +42,18 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: crd-creater
 rules:
-- apiGroups: ["*"]
+- apiGroups: ["networkservicemesh.io"]
   resources: ["*"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["*"]
+- apiGroups: ["extensions"]
+  resources: ["thirdpartyresources", "thirdpartyresources.extensions"]
+  verbs: ["*"]
+- apiGroups: ["*"] 
+  resources: ["pods"]
+  verbs: ["*"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/conf/sample/nse.yaml
+++ b/conf/sample/nse.yaml
@@ -44,7 +44,8 @@ spec:
   template:
     metadata:
       labels:
-        app: nse-1
+        networkservicemesh.io: "true"
+        networkservicemesh.io/app: "nse"
     spec:
       serviceAccount: nse
       containers:

--- a/plugins/finalizer/api.go
+++ b/plugins/finalizer/api.go
@@ -12,24 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nsmcommand
+package finalizer
 
-import (
-	"github.com/ligato/networkservicemesh/plugins/crd"
-	"github.com/ligato/networkservicemesh/plugins/finalizer"
-	"github.com/ligato/networkservicemesh/plugins/logger"
-	"github.com/ligato/networkservicemesh/plugins/nsmserver"
-	"github.com/ligato/networkservicemesh/plugins/objectstore"
-	"github.com/spf13/cobra"
-)
+import "github.com/ligato/networkservicemesh/plugins/idempotent"
 
-// Deps - dependencies for Plugin
-type Deps struct {
-	Name        string
-	Log         logger.FieldLogger
-	Cmd         *cobra.Command
-	NSMServer   nsmserver.PluginAPI
-	CRD         crd.PluginAPI
-	ObjectStore objectstore.Interface
-	Finalizer   finalizer.PluginAPI
+// PluginAPI for crd
+type PluginAPI interface {
+	idempotent.PluginAPI
 }

--- a/plugins/finalizer/finalizer_plugin.go
+++ b/plugins/finalizer/finalizer_plugin.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// //go:generate protoc -I ./model/pod --go_out=plugins=grpc:./model/pod ./model/pod/pod.proto
+
+package finalizer
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ligato/cn-infra/health/statuscheck"
+	"github.com/ligato/networkservicemesh/plugins/logger"
+	"github.com/ligato/networkservicemesh/plugins/objectstore"
+	"github.com/ligato/networkservicemesh/utils/command"
+	"github.com/ligato/networkservicemesh/utils/helper/deptools"
+	"github.com/ligato/networkservicemesh/utils/idempotent"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// Plugin watches K8s resources and causes all changes to be reflected in the ETCD
+// data store.
+type Plugin struct {
+	idempotent.Impl
+	Deps
+
+	pluginStopCh    chan struct{}
+	wg              sync.WaitGroup
+	k8sClientConfig *rest.Config
+	k8sClientset    *kubernetes.Clientset
+
+	StatusMonitor statuscheck.StatusReader
+
+	stopCh   chan struct{}
+	informer cache.SharedIndexInformer
+}
+
+// Deps defines dependencies of CRD plugin.
+type Deps struct {
+	Name string
+	Log  logger.FieldLoggerPlugin
+	// Kubeconfig with k8s cluster address and access credentials to use.
+	KubeConfig  string
+	ObjectStore objectstore.Interface
+}
+
+// Init builds K8s client-set based on the supplied kubeconfig and initializes
+// all reflectors.
+func (plugin *Plugin) Init() error {
+	return plugin.IdempotentInit(plugin.init)
+}
+func (plugin *Plugin) init() error {
+	plugin.pluginStopCh = make(chan struct{})
+	err := deptools.Init(plugin)
+	if err != nil {
+		return err
+	}
+	plugin.KubeConfig = command.RootCmd().Flags().Lookup(KubeConfigFlagName).Value.String()
+
+	plugin.Log.WithField("kubeconfig", plugin.KubeConfig).Info("Loading kubernetes client config")
+	plugin.k8sClientConfig, err = clientcmd.BuildConfigFromFlags("", plugin.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("Failed to build kubernetes client config: %s", err)
+	}
+
+	plugin.k8sClientset, err = kubernetes.NewForConfig(plugin.k8sClientConfig)
+	if err != nil {
+		return fmt.Errorf("failed to build kubernetes client: %s", err)
+	}
+
+	plugin.stopCh = make(chan struct{})
+
+	return plugin.afterInit()
+}
+
+func setupInformer(informer cache.SharedIndexInformer, queue workqueue.RateLimitingInterface) {
+	informer.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			DeleteFunc: func(obj interface{}) {
+				var message objectMessage
+				var err error
+				message.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				message.operation = deleteOp
+				message.obj = obj
+				if err == nil {
+					queue.Add(message)
+				}
+			},
+		},
+	)
+}
+
+func (plugin *Plugin) afterInit() error {
+	var err error
+
+	err = nil
+	if err != nil {
+		plugin.Log.Error("Error initializing Finalizer plugin")
+		return err
+	}
+
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	plugin.informer = cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return plugin.k8sClientset.CoreV1().Pods(metav1.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return plugin.k8sClientset.CoreV1().Pods(metav1.NamespaceAll).Watch(options)
+			},
+		},
+		&v1.Pod{},
+		10*time.Second,
+		cache.Indexers{},
+	)
+
+	setupInformer(plugin.informer, queue)
+
+	go plugin.informer.Run(plugin.stopCh)
+	plugin.Log.Info("Started  Finalizer's shared informer factory.")
+
+	// Wait for the informer caches to finish performing it's initial sync of
+	// resources
+	if !cache.WaitForCacheSync(plugin.stopCh, plugin.informer.HasSynced) {
+		plugin.Log.Error("Error waiting for informer cache to sync")
+	}
+	plugin.Log.Info("Finalizer's Informer cache is ready")
+
+	// Read forever from the work queue
+	go workforever(plugin, queue, plugin.informer, plugin.stopCh)
+
+	return nil
+}
+
+// Close stops all reflectors.
+func (plugin *Plugin) Close() error {
+	return plugin.IdempotentClose(plugin.close)
+}
+
+func (plugin *Plugin) close() error {
+	close(plugin.pluginStopCh)
+	plugin.wg.Wait()
+	return deptools.Close(plugin)
+}

--- a/plugins/finalizer/finalizer_plugin.go
+++ b/plugins/finalizer/finalizer_plugin.go
@@ -70,7 +70,7 @@ type Deps struct {
 	Name string
 	Log  logger.FieldLoggerPlugin
 	// Kubeconfig with k8s cluster address and access credentials to use.
-	KubeConfig  string `optional:"true"`
+	KubeConfig  string `empty_value_ok:"true"`
 	ObjectStore objectstore.Interface
 }
 

--- a/plugins/finalizer/finalizer_plugin.go
+++ b/plugins/finalizer/finalizer_plugin.go
@@ -70,7 +70,7 @@ type Deps struct {
 	Name string
 	Log  logger.FieldLoggerPlugin
 	// Kubeconfig with k8s cluster address and access credentials to use.
-	KubeConfig  string
+	KubeConfig  string `optional:"true"`
 	ObjectStore objectstore.Interface
 }
 

--- a/plugins/finalizer/finalizer_plugin.go
+++ b/plugins/finalizer/finalizer_plugin.go
@@ -108,13 +108,7 @@ func setupInformer(informer cache.SharedIndexInformer, queue workqueue.RateLimit
 	informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			DeleteFunc: func(obj interface{}) {
-				//				var message objectMessage
-				//				var err error
-				//				message.key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				//				message.obj = obj
-				// if err == nil {
 				queue.Add(obj)
-				// }
 			},
 		},
 	)

--- a/plugins/finalizer/finalizer_plugin.go
+++ b/plugins/finalizer/finalizer_plugin.go
@@ -38,6 +38,14 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
+const (
+	// Label to select pods treated by NSM controller
+	nsmLabel     = "networkservicemesh.io"
+	nsmAppLabel  = "networkservicemesh.io/app"
+	nsmAppNSE    = "nse"
+	nsmAppClient = "nsm-client"
+)
+
 // Plugin watches K8s resources and causes all changes to be reflected in the ETCD
 // data store.
 type Plugin struct {
@@ -124,9 +132,11 @@ func (plugin *Plugin) afterInit() error {
 	plugin.informer = cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				options.LabelSelector = nsmLabel + "=true"
 				return plugin.k8sClientset.CoreV1().Pods(metav1.NamespaceAll).List(options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.LabelSelector = nsmLabel + "=true"
 				return plugin.k8sClientset.CoreV1().Pods(metav1.NamespaceAll).Watch(options)
 			},
 		},

--- a/plugins/finalizer/finalizer_queue.go
+++ b/plugins/finalizer/finalizer_queue.go
@@ -83,7 +83,7 @@ func cleanUpNSE(plugin *Plugin, pod *v1.Pod) error {
 	}
 	// Step 2 range through received list of channels and for each found NetworkService, remove the channel
 	// from NetworkService object.
-	plugin.Log.Infof("found %d advertised channels found for NSE pod %s/%s", len(channels), pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
+	plugin.Log.Infof("found %d advertised channels for NSE pod %s/%s", len(channels), pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
 	for _, ch := range channels {
 		plugin.Log.Infof("channel %s/%s was used by netowrk service %s, deleting it...", ch.Metadata.Namespace, ch.Metadata.Name, ch.NetworkServiceName)
 		if err := plugin.ObjectStore.DeleteChannelFromNetworkService(ch.NetworkServiceName, ch.Metadata.Namespace, ch); err != nil {

--- a/plugins/finalizer/finalizer_queue.go
+++ b/plugins/finalizer/finalizer_queue.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// //go:generate protoc -I ./model/pod --go_out=plugins=grpc:./model/pod ./model/pod/pod.proto
+
+package finalizer
+
+import (
+	"reflect"
+
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// QueueRetryCount is the max number of times to retry processing a failed item
+// from the workqueue.
+const QueueRetryCount = 5
+
+const (
+	createOp = iota
+	deleteOp
+	updateOp
+)
+
+type objectMessage struct {
+	operation int
+	key       string
+	obj       interface{}
+}
+
+func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer cache.SharedIndexInformer, stopCH chan struct{}) {
+	for {
+		message, shutdown := queue.Get()
+
+		// If the queue has been shut down, we should exit the work queue here
+		if shutdown {
+			plugin.Log.Error("shutdown signaled, closing stopChNS")
+			close(stopCH)
+			return
+		}
+
+		var strKey string
+		strKey = message.(objectMessage).key
+
+		func(key string) {
+			defer queue.Done(message)
+
+			// Attempt to split the 'key' into namespace and object name
+			namespace, name, err := cache.SplitMetaNamespaceKey(strKey)
+
+			if err != nil {
+				// This is a soft-error
+				plugin.Log.Errorf("Error splitting meta namespace key into parts: %s", err.Error())
+				queue.Forget(message)
+				return
+			}
+
+			plugin.Log.Infof("Read item '%s/%s' off workqueue. Processing...", namespace, name)
+
+			plugin.Log.Infof("Found object of type: %s", reflect.TypeOf(message.(objectMessage).obj))
+			// Check if this is a create or delete operation
+			switch message.(objectMessage).operation {
+			case deleteOp:
+				plugin.Log.Infof("Got most up to date version of '%s/%s'. Syncing...", namespace, name)
+
+				plugin.Log.Infof("><SB> Got delete event for object type %+s", reflect.TypeOf(message.(objectMessage).obj))
+				plugin.ObjectStore.ObjectDeleted(message.(objectMessage).obj)
+			}
+
+			// As we managed to process this successfully, we can forget it
+			// from the work queue altogether.
+			queue.Forget(message)
+		}(strKey)
+	}
+}

--- a/plugins/finalizer/finalizer_queue.go
+++ b/plugins/finalizer/finalizer_queue.go
@@ -127,7 +127,7 @@ func cleanUpNSE(plugin *Plugin, pod *v1.Pod) error {
 	plugin.Log.Infof("found %d advertised channels found for NSE pod %s/%s", len(channels), pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
 	for _, ch := range channels {
 		plugin.Log.Infof("channel %s/%s was used by netowrk service %s, deleting it...", ch.Metadata.Namespace, ch.Metadata.Name, ch.NetworkServiceName)
-		if err := plugin.ObjectStore.DeleteChannelFromNS(ch); err != nil {
+		if err := plugin.ObjectStore.DeleteChannelFromNetworkService(ch); err != nil {
 			plugin.Log.Errorf("failed channel %s/%s from netowrk service %s with error: %+v", ch.Metadata.Namespace, ch.Metadata.Name, ch.NetworkServiceName, err)
 			return err
 		}

--- a/plugins/finalizer/finalizer_queue.go
+++ b/plugins/finalizer/finalizer_queue.go
@@ -127,7 +127,7 @@ func cleanUpNSE(plugin *Plugin, pod *v1.Pod) error {
 	plugin.Log.Infof("found %d advertised channels found for NSE pod %s/%s", len(channels), pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
 	for _, ch := range channels {
 		plugin.Log.Infof("channel %s/%s was used by netowrk service %s, deleting it...", ch.Metadata.Namespace, ch.Metadata.Name, ch.NetworkServiceName)
-		if err := plugin.ObjectStore.DeleteChannelFromNetworkService(ch); err != nil {
+		if err := plugin.ObjectStore.DeleteChannelFromNetworkService(ch.NetworkServiceName, ch.Metadata.Namespace, ch); err != nil {
 			plugin.Log.Errorf("failed channel %s/%s from netowrk service %s with error: %+v", ch.Metadata.Namespace, ch.Metadata.Name, ch.NetworkServiceName, err)
 			return err
 		}

--- a/plugins/finalizer/finalizer_queue.go
+++ b/plugins/finalizer/finalizer_queue.go
@@ -23,11 +23,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-//type objectMessage struct {
-//	key string
-//	obj interface{}
-//}
-
 func workforever(plugin *Plugin, queue workqueue.RateLimitingInterface, informer cache.SharedIndexInformer, stopCH chan struct{}) {
 	for {
 		obj, shutdown := queue.Get()

--- a/plugins/finalizer/options.go
+++ b/plugins/finalizer/options.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package finalizer
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/ligato/networkservicemesh/plugins/objectstore"
+
+	"github.com/ligato/networkservicemesh/plugins/logger"
+	"github.com/ligato/networkservicemesh/utils/command"
+)
+
+const (
+	// DefaultName of the finalizer.Plugin
+	DefaultName = "finalizer"
+	// KubeConfigFlagName - Cmd line flag for specifying kubeconfig filename
+	KubeConfigFlagName = "kube-config"
+	// KubeConfigFlagDefault - default value of KubeConfig
+	KubeConfigFlagDefault = ""
+	// KubeConfigFlagUsage - usage for flag for specifying kubeconfig filename
+	KubeConfigFlagUsage = "Path to the kubeconfig file to use for the client connection to K8s cluster"
+)
+
+// Option acts on a Plugin in order to set its Deps or Config
+type Option func(*Plugin)
+
+var sharedPlugins []*Plugin
+var sharedPluginLock sync.Mutex
+
+// NewPlugin creates a new Plugin with Deps/Config set by the supplied opts
+func NewPlugin(opts ...Option) *Plugin {
+	p := newPlugin(opts...)
+	sharedPlugins = append(sharedPlugins, p)
+	return p
+}
+
+func newPlugin(opts ...Option) *Plugin {
+	p := &Plugin{}
+	for _, o := range opts {
+		o(p)
+	}
+	DefaultDeps()(p)
+	return p
+}
+
+// SharedPlugin provides a single shared Plugin that has the same Deps/Config as would result
+// from the application of opts
+func SharedPlugin(opts ...Option) *Plugin {
+	p := newPlugin(opts...)
+	sharedPluginLock.Lock()
+	defer sharedPluginLock.Unlock()
+	_, plug := p.findSharedPlugin()
+	if plug != nil {
+		return plug
+	}
+	sharedPlugins = append(sharedPlugins, p)
+	return p
+}
+
+func (p *Plugin) findSharedPlugin() (int, *Plugin) {
+	for i, value := range sharedPlugins {
+		if reflect.DeepEqual(p.Deps, value.Deps) {
+			return i, value
+		}
+	}
+	return -1, nil
+}
+
+// UseDeps creates an Option to set the Deps for a Plugin
+func UseDeps(deps *Deps) Option {
+	return func(p *Plugin) {
+		d := &p.Deps
+		d.Name = deps.Name
+		d.Log = deps.Log
+		d.ObjectStore = deps.ObjectStore
+		d.KubeConfig = deps.KubeConfig
+	}
+}
+
+// DefaultDeps creates an Option to set any unset Dependencies to Default Values
+// DefaultDeps() is always applied by NewPlugin/SharedPlugin after all other Options
+func DefaultDeps() Option {
+	return func(p *Plugin) {
+		d := &p.Deps
+		if d.Name == "" {
+			d.Name = DefaultName
+		}
+		if d.Log == nil {
+			d.Log = logger.ByName(d.Name)
+		}
+		if d.ObjectStore == nil {
+			d.ObjectStore = objectstore.SharedPlugin()
+		}
+		if d.KubeConfig == "" {
+			cmd := command.RootCmd()
+			flag := cmd.Flags().Lookup(KubeConfigFlagName)
+			if flag == nil {
+				cmd.Flags().String(KubeConfigFlagName, KubeConfigFlagDefault, KubeConfigFlagUsage)
+				flag = cmd.Flags().Lookup(KubeConfigFlagName)
+			}
+		}
+	}
+}

--- a/plugins/nsmcommand/options.go
+++ b/plugins/nsmcommand/options.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ligato/networkservicemesh/utils/registry"
 
 	"github.com/ligato/networkservicemesh/plugins/crd"
+	"github.com/ligato/networkservicemesh/plugins/finalizer"
 	"github.com/ligato/networkservicemesh/plugins/logger"
 )
 
@@ -64,6 +65,7 @@ func UseDeps(deps *Deps) Option {
 		d.CRD = deps.CRD
 		d.NSMServer = deps.NSMServer
 		d.ObjectStore = deps.ObjectStore
+		d.Finalizer = deps.Finalizer
 	}
 }
 
@@ -89,6 +91,9 @@ func DefaultDeps() Option {
 		}
 		if d.ObjectStore == nil {
 			d.ObjectStore = objectstore.SharedPlugin()
+		}
+		if d.Finalizer == nil {
+			d.Finalizer = finalizer.SharedPlugin()
 		}
 	}
 }

--- a/plugins/nsmserver/nsmserver_client.go
+++ b/plugins/nsmserver/nsmserver_client.go
@@ -345,7 +345,8 @@ func (n *nsmClientEndpoints) RequestAdvertiseChannel(ctx context.Context, cr *ns
 				networkServiceName, networkServiceNamespace, c.Metadata.Name)
 			// Since it was discovered that NetworkService Object exists, calling method to add the channel to NetworkService.
 
-			// TODO (sbezverk) Advertised channel needs to be added to Object Store of channel.
+			// Adding advertised channel to Object Store of NSEs and channels.
+			n.objectStore.AddChannel(c)
 
 			if err := n.objectStore.AddChannelToNetworkService(networkServiceName, networkServiceNamespace, c); err != nil {
 				n.logger.Error("failed to add channel %s/%s to network service %s with error: %+v", networkServiceNamespace, networkServiceName, c.Metadata.Name, err)

--- a/plugins/nsmserver/nsmserver_client.go
+++ b/plugins/nsmserver/nsmserver_client.go
@@ -349,7 +349,7 @@ func (n *nsmClientEndpoints) RequestAdvertiseChannel(ctx context.Context, cr *ns
 			n.objectStore.AddChannel(c)
 
 			if err := n.objectStore.AddChannelToNetworkService(networkServiceName, networkServiceNamespace, c); err != nil {
-				n.logger.Error("failed to add channel %s/%s to network service %s with error: %+v", networkServiceNamespace, networkServiceName, c.Metadata.Name, err)
+				n.logger.Errorf("failed to add channel %s/%s to network service %s with error: %+v", networkServiceNamespace, networkServiceName, c.Metadata.Name, err)
 				return &nsmconnect.ChannelAdvertiseResponse{Success: false}, err
 			}
 			n.logger.Infof("Channel %s/%s has been successfully added to network service %s/%s in the Object Store",

--- a/plugins/nsmserver/nsmserver_client.go
+++ b/plugins/nsmserver/nsmserver_client.go
@@ -344,6 +344,9 @@ func (n *nsmClientEndpoints) RequestAdvertiseChannel(ctx context.Context, cr *ns
 			n.logger.Infof("Found existing NetworkService %s/%s in the Object Store, will add channel %s to its list of channels",
 				networkServiceName, networkServiceNamespace, c.Metadata.Name)
 			// Since it was discovered that NetworkService Object exists, calling method to add the channel to NetworkService.
+
+			// TODO (sbezverk) Advertised channel needs to be added to Object Store of channel.
+
 			if err := n.objectStore.AddChannelToNetworkService(networkServiceName, networkServiceNamespace, c); err != nil {
 				n.logger.Error("failed to add channel %s/%s to network service %s with error: %+v", networkServiceNamespace, networkServiceName, c.Metadata.Name, err)
 				return &nsmconnect.ChannelAdvertiseResponse{Success: false}, err

--- a/plugins/nsmserver/nsmserver_client.go
+++ b/plugins/nsmserver/nsmserver_client.go
@@ -316,7 +316,7 @@ func (n *nsmClientEndpoints) RequestDiscovery(ctx context.Context, cr *nsmconnec
 }
 
 func (n *nsmClientEndpoints) RequestAdvertiseChannel(ctx context.Context, cr *nsmconnect.ChannelAdvertiseRequest) (*nsmconnect.ChannelAdvertiseResponse, error) {
-	n.logger.Printf("received Channel advertisement...")
+	n.logger.Printf("received Channel advertisement.")
 	for _, c := range cr.NetmeshChannel {
 
 		// Ignoring path since it is local to NSE path, completely useless for server, but keeping NSE socket name
@@ -346,6 +346,7 @@ func (n *nsmClientEndpoints) RequestAdvertiseChannel(ctx context.Context, cr *ns
 			// Since it was discovered that NetworkService Object exists, calling method to add the channel to NetworkService.
 
 			// Adding advertised channel to Object Store of NSEs and channels.
+			n.logger.Infof("Adding channel %s/%s for NSE %s/%s", c.Metadata.Namespace, c.Metadata.Name, c.Metadata.Namespace, c.NseProviderName)
 			n.objectStore.AddChannel(c)
 
 			if err := n.objectStore.AddChannelToNetworkService(networkServiceName, networkServiceNamespace, c); err != nil {

--- a/plugins/objectstore/networkservice_test.go
+++ b/plugins/objectstore/networkservice_test.go
@@ -146,5 +146,3 @@ func TestDeletehannelToNetworkService(t *testing.T) {
 		t.Fatalf("Expected to see exactly 0 channel but got %d, failing", len(resultChannels))
 	}
 }
-
-// TODO (sbezverk) AddChannelToNetworkService and DeleteChannelFromNetworkService

--- a/plugins/objectstore/networkservice_test.go
+++ b/plugins/objectstore/networkservice_test.go
@@ -26,8 +26,11 @@ type networkserviceStore struct {
 }
 
 const (
-	nsTestName      = "EndpointTest"
-	nsTestNamespace = "default"
+	nsTestName          = "EndpointTest"
+	nsTestNamespace     = "default"
+	nchTestName         = "channel-1"
+	nchTestNamespace    = "default"
+	nseTestProviderName = "nse-1"
 )
 
 func TestNetworkServiceStore(t *testing.T) {
@@ -58,6 +61,89 @@ func TestNetworkServiceStore(t *testing.T) {
 	nsRet := networkservices.networkServicesStore.List()
 	if len(nsRet) != 0 {
 		t.Errorf("Deletion of NetworkService from objectstore failed")
+	}
+}
+
+func TestAddChannelToNetworkService(t *testing.T) {
+	networkservices := &networkserviceStore{}
+	networkservices.networkServicesStore = newNetworkServicesStore()
+
+	ns := netmesh.NetworkService{
+		Metadata: &common.Metadata{
+			Name:      nsTestName,
+			Namespace: nsTestNamespace,
+		},
+	}
+	nch := netmesh.NetworkServiceChannel{
+		Metadata: &common.Metadata{
+			Name:      nchTestName,
+			Namespace: nchTestNamespace,
+		},
+		NetworkServiceName: nsTestName,
+		NseProviderName:    nseTestProviderName,
+	}
+
+	networkservices.networkServicesStore.Add(&ns)
+
+	if err := networkservices.networkServicesStore.AddChannelToNetworkService(nsTestName, nsTestNamespace, &nch); err != nil {
+		t.Fatalf("AddChannel failed with error: %+v", err)
+	}
+	resultChannels, err := networkservices.networkServicesStore.ListChannelsForNetworkService(&ns)
+	if err != nil {
+		t.Fatalf("List channels for network service %s/%s failed with error: %+v", ns.Metadata.Namespace, ns.Metadata.Name, err)
+	}
+	if resultChannels == nil {
+		t.Fatalf("Channel slice for network service %s/%s should not be nil, but it is, failing", ns.Metadata.Namespace, ns.Metadata.Name)
+	}
+	if len(resultChannels) != 1 {
+		t.Fatalf("Expected to see exactly 1 channel but got %d, failing", len(resultChannels))
+	}
+}
+
+func TestDeletehannelToNetworkService(t *testing.T) {
+
+	networkservices := &networkserviceStore{}
+	networkservices.networkServicesStore = newNetworkServicesStore()
+
+	ns := netmesh.NetworkService{
+		Metadata: &common.Metadata{
+			Name:      nsTestName,
+			Namespace: nsTestNamespace,
+		},
+	}
+	nch := netmesh.NetworkServiceChannel{
+		Metadata: &common.Metadata{
+			Name:      nchTestName,
+			Namespace: nchTestNamespace,
+		},
+		NetworkServiceName: nsTestName,
+		NseProviderName:    nseTestProviderName,
+	}
+
+	networkservices.networkServicesStore.Add(&ns)
+
+	if err := networkservices.networkServicesStore.AddChannelToNetworkService(nsTestName, nsTestNamespace, &nch); err != nil {
+		t.Fatalf("AddChannelToNetworkService failed with error: %+v", err)
+	}
+	resultChannels, err := networkservices.networkServicesStore.ListChannelsForNetworkService(&ns)
+	if err != nil {
+		t.Fatalf("List channels for network service %s/%s failed with error: %+v", ns.Metadata.Namespace, ns.Metadata.Name, err)
+	}
+	if resultChannels == nil {
+		t.Fatalf("Channel slice for network service %s/%s should not be nil, but it is, failing", ns.Metadata.Namespace, ns.Metadata.Name)
+	}
+	if len(resultChannels) != 1 {
+		t.Fatalf("Expected to see exactly 1 channel but got %d, failing", len(resultChannels))
+	}
+	if err := networkservices.networkServicesStore.DeleteChannelFromNetworkService(nsTestName, nsTestNamespace, &nch); err != nil {
+		t.Fatalf("DeleteChannelToNetworkService failed with error: %+v", err)
+	}
+	resultChannels, err = networkservices.networkServicesStore.ListChannelsForNetworkService(&ns)
+	if err != nil {
+		t.Fatalf("List channels for network service %s/%s failed with error: %+v", ns.Metadata.Namespace, ns.Metadata.Name, err)
+	}
+	if len(resultChannels) != 0 {
+		t.Fatalf("Expected to see exactly 0 channel but got %d, failing", len(resultChannels))
 	}
 }
 

--- a/plugins/objectstore/networkservice_test.go
+++ b/plugins/objectstore/networkservice_test.go
@@ -60,3 +60,5 @@ func TestNetworkServiceStore(t *testing.T) {
 		t.Errorf("Deletion of NetworkService from objectstore failed")
 	}
 }
+
+// TODO (sbezverk) AddChannelToNetworkService and DeleteChannelFromNetworkService

--- a/plugins/objectstore/networkservicechannels.go
+++ b/plugins/objectstore/networkservicechannels.go
@@ -17,6 +17,8 @@ package objectstore
 import (
 	"sync"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh"
 )
 
@@ -45,19 +47,22 @@ func (n *networkServiceChannelsStore) AddChannel(nch *netmesh.NetworkServiceChan
 		namespace: nch.Metadata.Namespace,
 	}
 	found := false
-	if _, ok := n.networkServiceChannel[key]; !ok {
+	if channels, ok := n.networkServiceChannel[key]; !ok {
 		// Not in the store, meaning it will be a first channel for NSE
+		logrus.Infof("><SB> NSE with key: %+v not found, adding it...", key)
 		n.networkServiceChannel[key] = append(n.networkServiceChannel[key], nch)
 	} else {
 		// NSE already exists, now need to check is the channel is not duplicate
 		// and if it is not, then add it.
-		for _, c := range n.networkServiceChannel[key] {
-			if c.Metadata.Name == nch.Metadata.Name &&
-				c.Metadata.Namespace == nch.Metadata.Namespace {
+		for _, ch := range channels {
+			if ch.Metadata.Name == nch.Metadata.Name &&
+				ch.Metadata.Namespace == nch.Metadata.Namespace {
+				logrus.Infof("><SB> Channel %s/%s already exists", nch.Metadata.Namespace, nch.Metadata.Name)
 				found = true
 			}
 		}
 		if !found {
+			logrus.Infof("><SB> Channel %s/%s is new, adding it", nch.Metadata.Namespace, nch.Metadata.Name)
 			n.networkServiceChannel[key] = append(n.networkServiceChannel[key], nch)
 		}
 	}
@@ -96,6 +101,7 @@ func (n *networkServiceChannelsStore) DeleteNSE(nseServer, namespace string) {
 }
 
 // List method lists all known NetworkServiceChannel objects.
+/*
 func (n *networkServiceChannelsStore) List() []*netmesh.NetworkServiceChannel {
 	n.Lock()
 	defer n.Unlock()
@@ -106,6 +112,7 @@ func (n *networkServiceChannelsStore) List() []*netmesh.NetworkServiceChannel {
 
 	return networkServiceChannels
 }
+*/
 
 // GetChannelsByNSEServerProvider returns a slice of channels for specified nse_server_provider + namespace key
 func (n *networkServiceChannelsStore) GetChannelsByNSEServerProvider(nseServer, namespace string) []*netmesh.NetworkServiceChannel {

--- a/plugins/objectstore/networkservicechannels.go
+++ b/plugins/objectstore/networkservicechannels.go
@@ -17,8 +17,6 @@ package objectstore
 import (
 	"sync"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh"
 )
 
@@ -49,7 +47,6 @@ func (n *networkServiceChannelsStore) AddChannel(nch *netmesh.NetworkServiceChan
 	found := false
 	if channels, ok := n.networkServiceChannel[key]; !ok {
 		// Not in the store, meaning it will be a first channel for NSE
-		logrus.Infof("><SB> NSE with key: %+v not found, adding it...", key)
 		n.networkServiceChannel[key] = append(n.networkServiceChannel[key], nch)
 	} else {
 		// NSE already exists, now need to check is the channel is not duplicate
@@ -57,12 +54,10 @@ func (n *networkServiceChannelsStore) AddChannel(nch *netmesh.NetworkServiceChan
 		for _, ch := range channels {
 			if ch.Metadata.Name == nch.Metadata.Name &&
 				ch.Metadata.Namespace == nch.Metadata.Namespace {
-				logrus.Infof("><SB> Channel %s/%s already exists", nch.Metadata.Namespace, nch.Metadata.Name)
 				found = true
 			}
 		}
 		if !found {
-			logrus.Infof("><SB> Channel %s/%s is new, adding it", nch.Metadata.Namespace, nch.Metadata.Name)
 			n.networkServiceChannel[key] = append(n.networkServiceChannel[key], nch)
 		}
 	}
@@ -99,20 +94,6 @@ func (n *networkServiceChannelsStore) DeleteNSE(nseServer, namespace string) {
 		delete(n.networkServiceChannel, key)
 	}
 }
-
-// List method lists all known NetworkServiceChannel objects.
-/*
-func (n *networkServiceChannelsStore) List() []*netmesh.NetworkServiceChannel {
-	n.Lock()
-	defer n.Unlock()
-	networkServiceChannels := make([]*netmesh.NetworkServiceChannel, 0)
-	for _, ns := range n.networkServiceChannel {
-		networkServiceChannels = append(networkServiceChannels, ns...)
-	}
-
-	return networkServiceChannels
-}
-*/
 
 // GetChannelsByNSEServerProvider returns a slice of channels for specified nse_server_provider + namespace key
 func (n *networkServiceChannelsStore) GetChannelsByNSEServerProvider(nseServer, namespace string) []*netmesh.NetworkServiceChannel {

--- a/plugins/objectstore/networkservicechannels.go
+++ b/plugins/objectstore/networkservicechannels.go
@@ -60,6 +60,20 @@ func (n *networkServiceChannelsStore) Delete(key meta) {
 	}
 }
 
+// DeleteNSE method deletes removed NetworkServiceChannel object from the store.
+func (n *networkServiceChannelsStore) DeleteNSE(nseServer, namespace string) {
+	n.Lock()
+	defer n.Unlock()
+
+	key := meta{
+		name:      nseServer,
+		namespace: namespace,
+	}
+	if _, ok := n.networkServiceChannel[key]; ok {
+		delete(n.networkServiceChannel, key)
+	}
+}
+
 // List method lists all known NetworkServiceChannel objects.
 func (n *networkServiceChannelsStore) List() []*netmesh.NetworkServiceChannel {
 	n.Lock()
@@ -70,4 +84,16 @@ func (n *networkServiceChannelsStore) List() []*netmesh.NetworkServiceChannel {
 	}
 
 	return networkServiceChannels
+}
+
+// GetChannelsByNSEServerProvider returns a slice of channels for specified nse_server_provider + namespace key
+func (n *networkServiceChannelsStore) GetChannelsByNSEServerProvider(nseServer, namespace string) []*netmesh.NetworkServiceChannel {
+	key := meta{
+		name:      nseServer,
+		namespace: namespace,
+	}
+	if list, ok := n.networkServiceChannel[key]; ok {
+		return list
+	}
+	return nil
 }

--- a/plugins/objectstore/networkservicechannels_test.go
+++ b/plugins/objectstore/networkservicechannels_test.go
@@ -43,7 +43,7 @@ func TestChannelStore(t *testing.T) {
 		NetworkServiceName: "network-service-1",
 	}
 
-	channels.networkServiceChannelsStore.Add(&nsc)
+	channels.networkServiceChannelsStore.AddChannel(&nsc)
 
 	for _, n := range channels.networkServiceChannelsStore.List() {
 		if n.Metadata.Name != chTestName {
@@ -55,7 +55,7 @@ func TestChannelStore(t *testing.T) {
 		}
 	}
 
-	channels.networkServiceChannelsStore.Delete(meta{name: nsc.NseProviderName, namespace: nsc.Metadata.Namespace})
+	channels.networkServiceChannelsStore.DeleteChannel(&nsc)
 
 	nscRet := channels.networkServiceChannelsStore.List()
 	if len(nscRet) != 0 {

--- a/plugins/objectstore/networkservicechannels_test.go
+++ b/plugins/objectstore/networkservicechannels_test.go
@@ -25,40 +25,43 @@ type channelStore struct {
 	*networkServiceChannelsStore
 }
 
-const (
-	chTestName      = "ChannelTest"
-	chTestNamespace = "default"
-)
-
 func TestChannelStore(t *testing.T) {
 	channels := &channelStore{}
 	channels.networkServiceChannelsStore = newNetworkServiceChannelsStore()
 
-	nsc := netmesh.NetworkServiceChannel{
+	nsc1 := netmesh.NetworkServiceChannel{
 		Metadata: &common.Metadata{
-			Name:      chTestName,
-			Namespace: chTestNamespace,
+			Name:      "channel-1",
+			Namespace: "default",
 		},
 		NseProviderName:    "host1",
 		NetworkServiceName: "network-service-1",
 	}
 
-	channels.networkServiceChannelsStore.AddChannel(&nsc)
-
-	for _, n := range channels.networkServiceChannelsStore.List() {
-		if n.Metadata.Name != chTestName {
-			t.Errorf("Unexpected Name value returned when creating NetworkServiceChannel")
-		}
-
-		if n.Metadata.Namespace != chTestNamespace {
-			t.Errorf("Unexpected Namespace value returned when creating NetworkServiceChannel")
-		}
+	nsc2 := netmesh.NetworkServiceChannel{
+		Metadata: &common.Metadata{
+			Name:      "channel-2",
+			Namespace: "default",
+		},
+		NseProviderName:    "host1",
+		NetworkServiceName: "network-service-1",
 	}
 
-	channels.networkServiceChannelsStore.DeleteChannel(&nsc)
+	channels.networkServiceChannelsStore.AddChannel(&nsc1)
+	channels.networkServiceChannelsStore.AddChannel(&nsc2)
 
-	nscRet := channels.networkServiceChannelsStore.List()
-	if len(nscRet) != 0 {
-		t.Errorf("Deletion of NetworkServiceChannel from objectstore failed")
+	nseChannels := channels.networkServiceChannelsStore.GetChannelsByNSEServerProvider("host1", "default")
+	if len(nseChannels) != 2 {
+		t.Fatalf("expected to get exactly 2 channels but got %d", len(nseChannels))
+	}
+	channels.networkServiceChannelsStore.DeleteChannel(&nsc1)
+	nseChannels = channels.networkServiceChannelsStore.GetChannelsByNSEServerProvider("host1", "default")
+	if len(nseChannels) != 1 {
+		t.Fatalf("expected to get exactly 1 channels but got %d", len(nseChannels))
+	}
+	channels.networkServiceChannelsStore.DeleteChannel(&nsc2)
+	nseChannels = channels.networkServiceChannelsStore.GetChannelsByNSEServerProvider("host1", "default")
+	if len(nseChannels) != 0 {
+		t.Fatalf("expected to get exactly 0 channels but got %d", len(nseChannels))
 	}
 }

--- a/plugins/objectstore/networkservices.go
+++ b/plugins/objectstore/networkservices.go
@@ -70,7 +70,7 @@ func (n *networkServicesStore) Get(nsName, nsNamespace string) *netmesh.NetworkS
 
 // Get method returns NetworkService, if it does not
 // already it returns nil.
-func (n *networkServicesStore) AddChannel(nsName string, nsNamespace string, ch *netmesh.NetworkServiceChannel) error {
+func (n *networkServicesStore) AddChannelToNetworkService(nsName string, nsNamespace string, ch *netmesh.NetworkServiceChannel) error {
 	n.Lock()
 	defer n.Unlock()
 
@@ -102,13 +102,13 @@ func (n *networkServicesStore) AddChannel(nsName string, nsNamespace string, ch 
 }
 
 // DeleteChannel deletes channel from Network Service
-func (n *networkServicesStore) DeleteChannelFromNS(ch *netmesh.NetworkServiceChannel) error {
+func (n *networkServicesStore) DeleteChannelFromNetworkService(nsName string, nsNamespace string, ch *netmesh.NetworkServiceChannel) error {
 	n.Lock()
 	defer n.Unlock()
 
 	key := meta{
-		name:      ch.NetworkServiceName,
-		namespace: ch.Metadata.Namespace,
+		name:      nsName,
+		namespace: nsNamespace,
 	}
 	ns, ok := n.networkService[key]
 	if !ok {
@@ -146,4 +146,19 @@ func (n *networkServicesStore) List() []*netmesh.NetworkService {
 		networkServices = append(networkServices, ns)
 	}
 	return networkServices
+}
+
+func (n *networkServicesStore) ListChannelsForNetworkService(ns *netmesh.NetworkService) ([]*netmesh.NetworkServiceChannel, error) {
+	n.Lock()
+	defer n.Unlock()
+
+	key := meta{
+		name:      ns.Metadata.Name,
+		namespace: ns.Metadata.Namespace,
+	}
+	ns, ok := n.networkService[key]
+	if !ok {
+		return nil, fmt.Errorf("failed to find network service %s/%s in the object store", key.namespace, key.name)
+	}
+	return ns.Channel, nil
 }

--- a/plugins/objectstore/objectstore_api.go
+++ b/plugins/objectstore/objectstore_api.go
@@ -34,9 +34,12 @@ type Interface interface {
 	ObjectDeleted(obj interface{})
 	GetNetworkService(nsName, nsNamespace string) *netmesh.NetworkService
 	AddChannelToNetworkService(nsName string, nsNamespace string, ch *netmesh.NetworkServiceChannel) error
+	DeleteChannelFromNS(*netmesh.NetworkServiceChannel) error
+	DeleteNSE(nseServer, namespace string)
 	ListNetworkServices() []*netmesh.NetworkService
 	ListNetworkServiceChannels() []*netmesh.NetworkServiceChannel
 	ListNetworkServiceEndpoints() []*netmesh.NetworkServiceEndpoint
+	GetChannelsByNSEServerProvider(nseServer, namespace string) []*netmesh.NetworkServiceChannel
 }
 
 // PluginAPI - API for the Plugin

--- a/plugins/objectstore/objectstore_api.go
+++ b/plugins/objectstore/objectstore_api.go
@@ -35,7 +35,7 @@ type Interface interface {
 	GetNetworkService(nsName, nsNamespace string) *netmesh.NetworkService
 	AddChannelToNetworkService(nsName string, nsNamespace string, ch *netmesh.NetworkServiceChannel) error
 	AddChannel(nch *netmesh.NetworkServiceChannel)
-	DeleteChannelFromNetworkService(*netmesh.NetworkServiceChannel) error
+	DeleteChannelFromNetworkService(nsName string, nsNamespace string, ch *netmesh.NetworkServiceChannel) error
 	DeleteNSE(nseServer, namespace string)
 	ListNetworkServices() []*netmesh.NetworkService
 	ListNetworkServiceChannels() []*netmesh.NetworkServiceChannel

--- a/plugins/objectstore/objectstore_api.go
+++ b/plugins/objectstore/objectstore_api.go
@@ -38,8 +38,6 @@ type Interface interface {
 	DeleteChannelFromNetworkService(nsName string, nsNamespace string, ch *netmesh.NetworkServiceChannel) error
 	DeleteNSE(nseServer, namespace string)
 	ListNetworkServices() []*netmesh.NetworkService
-	ListNetworkServiceChannels() []*netmesh.NetworkServiceChannel
-	ListNetworkServiceEndpoints() []*netmesh.NetworkServiceEndpoint
 	GetChannelsByNSEServerProvider(nseServer, namespace string) []*netmesh.NetworkServiceChannel
 }
 

--- a/plugins/objectstore/objectstore_api.go
+++ b/plugins/objectstore/objectstore_api.go
@@ -34,7 +34,8 @@ type Interface interface {
 	ObjectDeleted(obj interface{})
 	GetNetworkService(nsName, nsNamespace string) *netmesh.NetworkService
 	AddChannelToNetworkService(nsName string, nsNamespace string, ch *netmesh.NetworkServiceChannel) error
-	DeleteChannelFromNS(*netmesh.NetworkServiceChannel) error
+	AddChannel(nch *netmesh.NetworkServiceChannel)
+	DeleteChannelFromNetworkService(*netmesh.NetworkServiceChannel) error
 	DeleteNSE(nseServer, namespace string)
 	ListNetworkServices() []*netmesh.NetworkService
 	ListNetworkServiceChannels() []*netmesh.NetworkServiceChannel

--- a/plugins/objectstore/objectstore_plugin.go
+++ b/plugins/objectstore/objectstore_plugin.go
@@ -127,18 +127,6 @@ func (p *Plugin) ListNetworkServices() []*netmesh.NetworkService {
 	return p.objects.networkServicesStore.List()
 }
 
-// ListNetworkServiceChannels lists all stored NetworkServiceChannel objects
-func (p *Plugin) ListNetworkServiceChannels() []*netmesh.NetworkServiceChannel {
-	p.Log.Info("ObjectStore.ListNetworkServiceChannels")
-	return p.objects.networkServiceChannelsStore.List()
-}
-
-// ListNetworkServiceEndpoints lists all stored NetworkServiceEndpoint objects
-func (p *Plugin) ListNetworkServiceEndpoints() []*netmesh.NetworkServiceEndpoint {
-	p.Log.Info("ObjectStore.ListNetworkServiceEndpoints")
-	return p.objects.networkServiceEndpointsStore.List()
-}
-
 // ObjectDeleted is called when an object is deleted
 func (p *Plugin) ObjectDeleted(obj interface{}) {
 	p.Log.Infof("ObjectStore.ObjectDeleted: %s", obj)
@@ -157,7 +145,8 @@ func (p *Plugin) ObjectDeleted(obj interface{}) {
 
 // GetChannelsByNSEServerProvider lists all stored NetworkServiceChannel objects for a given nse server
 func (p *Plugin) GetChannelsByNSEServerProvider(nseServer, namespace string) []*netmesh.NetworkServiceChannel {
-	p.Log.Info("ObjectStore.ListNetworkServiceChannels")
+	p.Log.Info("ObjectStore.GetChannelsByNSEServerProvider for %s/%s", nseServer, namespace)
+	p.Log.Infof("><SB> Dumping content of channel store: %+v", p.objects.networkServiceChannel)
 	return p.objects.networkServiceChannelsStore.GetChannelsByNSEServerProvider(nseServer, namespace)
 }
 
@@ -170,6 +159,7 @@ func (p *Plugin) DeleteNSE(nseServer, namespace string) {
 // DeleteChannel delete all channels associated with given NSE
 func (p *Plugin) DeleteChannel(nch *netmesh.NetworkServiceChannel) {
 	p.Log.Info("ObjectStore.DeleteChannel")
+	p.Log.Infof("><SB> Dumping content of channel store: %+v", p.objects.networkServiceChannel)
 	p.objects.networkServiceChannelsStore.DeleteChannel(nch)
 }
 
@@ -177,5 +167,6 @@ func (p *Plugin) DeleteChannel(nch *netmesh.NetworkServiceChannel) {
 // othewise NSE gets created and then new channel gets added.
 func (p *Plugin) AddChannel(nch *netmesh.NetworkServiceChannel) {
 	p.Log.Info("ObjectStore.AddChannel")
-	p.objects.networkServiceChannelsStore.DeleteChannel(nch)
+	p.Log.Infof("><SB> Dumping content of channel store: %+v", p.objects.networkServiceChannel)
+	p.objects.networkServiceChannelsStore.AddChannel(nch)
 }

--- a/plugins/objectstore/objectstore_plugin.go
+++ b/plugins/objectstore/objectstore_plugin.go
@@ -146,7 +146,6 @@ func (p *Plugin) ObjectDeleted(obj interface{}) {
 // GetChannelsByNSEServerProvider lists all stored NetworkServiceChannel objects for a given nse server
 func (p *Plugin) GetChannelsByNSEServerProvider(nseServer, namespace string) []*netmesh.NetworkServiceChannel {
 	p.Log.Info("ObjectStore.GetChannelsByNSEServerProvider for %s/%s", nseServer, namespace)
-	p.Log.Infof("><SB> Dumping content of channel store: %+v", p.objects.networkServiceChannel)
 	return p.objects.networkServiceChannelsStore.GetChannelsByNSEServerProvider(nseServer, namespace)
 }
 
@@ -159,7 +158,6 @@ func (p *Plugin) DeleteNSE(nseServer, namespace string) {
 // DeleteChannel delete all channels associated with given NSE
 func (p *Plugin) DeleteChannel(nch *netmesh.NetworkServiceChannel) {
 	p.Log.Info("ObjectStore.DeleteChannel")
-	p.Log.Infof("><SB> Dumping content of channel store: %+v", p.objects.networkServiceChannel)
 	p.objects.networkServiceChannelsStore.DeleteChannel(nch)
 }
 
@@ -167,6 +165,5 @@ func (p *Plugin) DeleteChannel(nch *netmesh.NetworkServiceChannel) {
 // othewise NSE gets created and then new channel gets added.
 func (p *Plugin) AddChannel(nch *netmesh.NetworkServiceChannel) {
 	p.Log.Info("ObjectStore.AddChannel")
-	p.Log.Infof("><SB> Dumping content of channel store: %+v", p.objects.networkServiceChannel)
 	p.objects.networkServiceChannelsStore.AddChannel(nch)
 }

--- a/plugins/objectstore/objectstore_plugin.go
+++ b/plugins/objectstore/objectstore_plugin.go
@@ -112,13 +112,13 @@ func (p *Plugin) GetNetworkService(nsName, nsNamespace string) *netmesh.NetworkS
 // AddChannelToNetworkService adds a channel to Existing in the ObjectStore NetworkService object
 func (p *Plugin) AddChannelToNetworkService(nsName string, nsNamespace string, ch *netmesh.NetworkServiceChannel) error {
 	p.Log.Info("ObjectStore.AddChannelToNetworkService.")
-	return p.objects.networkServicesStore.AddChannel(nsName, nsNamespace, ch)
+	return p.objects.networkServicesStore.AddChannelToNetworkService(nsName, nsNamespace, ch)
 }
 
 // DeleteChannelFromNetworkService deletes a channel from the ObjectStore NetworkService object
-func (p *Plugin) DeleteChannelFromNetworkService(ch *netmesh.NetworkServiceChannel) error {
+func (p *Plugin) DeleteChannelFromNetworkService(nsName string, nsNamespace string, ch *netmesh.NetworkServiceChannel) error {
 	p.Log.Info("ObjectStore.DeleteChannelFromNetworkService.")
-	return p.objects.networkServicesStore.DeleteChannelFromNS(ch)
+	return p.objects.networkServicesStore.DeleteChannelFromNetworkService(nsName, nsNamespace, ch)
 }
 
 // ListNetworkServices lists all stored NetworkService objects

--- a/plugins/objectstore/objectstore_plugin.go
+++ b/plugins/objectstore/objectstore_plugin.go
@@ -115,6 +115,12 @@ func (p *Plugin) AddChannelToNetworkService(nsName string, nsNamespace string, c
 	return p.objects.networkServicesStore.AddChannel(nsName, nsNamespace, ch)
 }
 
+// DeleteChannelFromNS deletes a channel from the ObjectStore NetworkService object
+func (p *Plugin) DeleteChannelFromNS(ch *netmesh.NetworkServiceChannel) error {
+	p.Log.Info("ObjectStore.DeleteChannelFromNetworkService.")
+	return p.objects.networkServicesStore.DeleteChannelFromNS(ch)
+}
+
 // ListNetworkServices lists all stored NetworkService objects
 func (p *Plugin) ListNetworkServices() []*netmesh.NetworkService {
 	p.Log.Info("ObjectStore.ListNetworkServices.")
@@ -147,4 +153,16 @@ func (p *Plugin) ObjectDeleted(obj interface{}) {
 		nse := obj.(*v1.NetworkServiceEndpoint).Spec
 		p.objects.networkServiceEndpointsStore.Delete(meta{name: nse.Metadata.Name, namespace: nse.Metadata.Namespace})
 	}
+}
+
+// GetChannelsByNSEServerProvider lists all stored NetworkServiceChannel objects for a given nse server
+func (p *Plugin) GetChannelsByNSEServerProvider(nseServer, namespace string) []*netmesh.NetworkServiceChannel {
+	p.Log.Info("ObjectStore.ListNetworkServiceChannels")
+	return p.objects.networkServiceChannelsStore.GetChannelsByNSEServerProvider(nseServer, namespace)
+}
+
+// DeleteNSE delete all channels associated with given NSE
+func (p *Plugin) DeleteNSE(nseServer, namespace string) {
+	p.Log.Info("ObjectStore.DeleteNSE")
+	p.objects.networkServiceChannelsStore.DeleteNSE(nseServer, namespace)
 }

--- a/plugins/objectstore/objectstore_plugin.go
+++ b/plugins/objectstore/objectstore_plugin.go
@@ -94,7 +94,7 @@ func (p *Plugin) ObjectCreated(obj interface{}) {
 		p.Log.Infof("number of network services in Object Store %d", len(p.objects.networkServicesStore.List()))
 	case *v1.NetworkServiceChannel:
 		nsc := obj.(*v1.NetworkServiceChannel).Spec
-		p.objects.networkServiceChannelsStore.Add(&nsc)
+		p.objects.networkServiceChannelsStore.AddChannel(&nsc)
 	case *v1.NetworkServiceEndpoint:
 		nse := obj.(*v1.NetworkServiceEndpoint).Spec
 		p.objects.networkServiceEndpointsStore.Add(&nse)
@@ -115,8 +115,8 @@ func (p *Plugin) AddChannelToNetworkService(nsName string, nsNamespace string, c
 	return p.objects.networkServicesStore.AddChannel(nsName, nsNamespace, ch)
 }
 
-// DeleteChannelFromNS deletes a channel from the ObjectStore NetworkService object
-func (p *Plugin) DeleteChannelFromNS(ch *netmesh.NetworkServiceChannel) error {
+// DeleteChannelFromNetworkService deletes a channel from the ObjectStore NetworkService object
+func (p *Plugin) DeleteChannelFromNetworkService(ch *netmesh.NetworkServiceChannel) error {
 	p.Log.Info("ObjectStore.DeleteChannelFromNetworkService.")
 	return p.objects.networkServicesStore.DeleteChannelFromNS(ch)
 }
@@ -148,7 +148,7 @@ func (p *Plugin) ObjectDeleted(obj interface{}) {
 		p.objects.networkServicesStore.Delete(meta{name: ns.Metadata.Name, namespace: ns.Metadata.Namespace})
 	case *v1.NetworkServiceChannel:
 		nsc := obj.(*v1.NetworkServiceChannel).Spec
-		p.objects.networkServiceChannelsStore.Delete(meta{name: nsc.Metadata.Name, namespace: nsc.Metadata.Namespace})
+		p.objects.networkServiceChannelsStore.DeleteChannel(&nsc)
 	case *v1.NetworkServiceEndpoint:
 		nse := obj.(*v1.NetworkServiceEndpoint).Spec
 		p.objects.networkServiceEndpointsStore.Delete(meta{name: nse.Metadata.Name, namespace: nse.Metadata.Namespace})
@@ -165,4 +165,17 @@ func (p *Plugin) GetChannelsByNSEServerProvider(nseServer, namespace string) []*
 func (p *Plugin) DeleteNSE(nseServer, namespace string) {
 	p.Log.Info("ObjectStore.DeleteNSE")
 	p.objects.networkServiceChannelsStore.DeleteNSE(nseServer, namespace)
+}
+
+// DeleteChannel delete all channels associated with given NSE
+func (p *Plugin) DeleteChannel(nch *netmesh.NetworkServiceChannel) {
+	p.Log.Info("ObjectStore.DeleteChannel")
+	p.objects.networkServiceChannelsStore.DeleteChannel(nch)
+}
+
+// AddChannel checks if advertised NSE already exists and then add given channel to its list,
+// othewise NSE gets created and then new channel gets added.
+func (p *Plugin) AddChannel(nch *netmesh.NetworkServiceChannel) {
+	p.Log.Info("ObjectStore.AddChannel")
+	p.objects.networkServiceChannelsStore.DeleteChannel(nch)
 }


### PR DESCRIPTION
Currently there is no any cleanup when pod providing nse channel goes away, same issue is with nsm client. This controller in  form of another plugin will watch for this event (label based) and attempt to clean up.
Since PR became kind of large, dataplane clean up for NSE will be in the next PR.