### PR TITLE
Export Makefile variables so they can be used by shell scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,17 @@ GOVETTARGETS=cmd \
 	plugins \
 	utils
 
+# Export some of the above variables so they persist for the shell scripts
+# which are run from the Makefiles
+export GOPATH \
+       GOCMD \
+       GOFMT \
+       GOGET \
+       GOGENERATE \
+       GOINSTALL \
+       GOTEST \
+       GOVET
+
 # Setup proxies for docker build
 ifeq ($(HTTP_PROXY),)
 HTTPBUILD=


### PR DESCRIPTION
Closes #187

Specifically, this will export GOPATH, which is needed by the shell scripts
run by the `make verify` target.

Signed-off-by: Kyle Mestery <mestery@mestery.com>