### PR TITLE
Fix for corner case which can throw nil panic

### DIFF
--- a/plugins/logger/impl.go
+++ b/plugins/logger/impl.go
@@ -41,7 +41,10 @@ func (p *Plugin) Init() error {
 
 func (p *Plugin) init() error {
 	p.Log = logrus.New()
-	p.Deps.ConfigLoader.Init()
+	err := p.Deps.ConfigLoader.Init()
+	if err != nil {
+		return err
+	}
 	if p.Config == nil {
 		p.Config = p.Deps.ConfigLoader.LoadConfig().(*Config)
 	}

--- a/plugins/logger/options.go
+++ b/plugins/logger/options.go
@@ -43,6 +43,9 @@ func NewPlugin(opts ...Option) *Plugin {
 		o(p)
 	}
 	DefaultDeps()(p)
+	// Set a defensive p.FieldLogger so its *never* nil
+	// This should be overwritten by something proper in Init()
+	p.FieldLogger = p.Log
 	return p
 }
 


### PR DESCRIPTION
If logger.Plugin.init() produces an error before
setting the FieldLogger field, downstream consumers
can get a nil panic.