### PR TITLE
Ensure veth interfaces are in the UP state

### DIFF
--- a/cmd/simple-dataplane/simple-dataplane.go
+++ b/cmd/simple-dataplane/simple-dataplane.go
@@ -208,12 +208,18 @@ func setVethPair(ns1, ns2 netns.NsHandle, p1, p2 string) error {
 	if _, ok := link.(*netlink.Veth); !ok {
 		return fmt.Errorf("failure, got unexpected interface type: %+v", reflect.TypeOf(link))
 	}
+	if netlink.LinkSetUp(link) != nil {
+		return fmt.Errorf("failure setting link %s up", link)
+	}
 	peer, err := netlink.LinkByName(p1)
 	if err != nil {
 		return fmt.Errorf("failure to get pod's interface by name with error: %+v", err)
 	}
 	if _, ok := peer.(*netlink.Veth); !ok {
 		return fmt.Errorf("failure, got unexpected interface type: %+v", reflect.TypeOf(link))
+	}
+	if netlink.LinkSetUp(peer) != nil {
+		return fmt.Errorf("failure setting link %s up", peer)
 	}
 	if err := netlink.LinkSetNsFd(peer, int(ns2)); err != nil {
 		return fmt.Errorf("failure to get place veth into peer's pod with error: %+v", err)


### PR DESCRIPTION
I have noticed in my own testing environment the interfaces the simple-dataplane
creates do not show as "UP".

Note that even with this patch ping's from the NSE to the client still do not
work for me.

Signed-off-by: Kyle Mestery <mestery@mestery.com>