### PR TITLE
Add the ability to publish images to Docker Hub

### DIFF
--- a/.nsm.mk
+++ b/.nsm.mk
@@ -1,0 +1,92 @@
+# Copyright (c) 2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file includes definitions for Docker images used by the Makefile
+# and docker build infrastructure. It also contains the targets to build
+# and push Docker images
+
+DOCKER_NETMESH_TEST=networkservicemesh/nsm-daemon-test
+DOCKER_NETMESH=networkservicemesh/nsm-daemon
+DOCKER_SIMPLE_DATAPLANE=networkservicemesh/nsm-simple-dataplane
+DOCKER_NSM_INIT=networkservicemesh/nsm-init
+DOCKER_NSE=networkservicemesh/nse
+DOCKER_RELEASE=networkservicemesh/release
+
+#
+# Targets to build docker images
+#
+.PHONY: docker-build-netmesh-test
+docker-build-netmesh-test:
+	@${DOCKERBUILD} -t ${DOCKER_NETMESH_TEST} -f build/nsm/docker/Test.Dockerfile .
+
+.PHONY: docker-build-release
+docker-build-release:
+	@${DOCKERBUILD} -t ${DOCKER_RELEASE} -f build/Dockerfile .
+
+.PHONY: docker-build-netmesh
+docker-build-netmesh: docker-build-release
+	@${DOCKERBUILD} -t ${DOCKER_NETMESH} -f build/nsm/docker/Dockerfile .
+
+.PHONY: docker-build-simple-dataplane
+docker-build-simple-dataplane: docker-build-release
+	@docker build -t ${DOCKER_SIMPLE_DATAPLANE} -f build/simple-dataplane/docker/Dockerfile .
+
+.PHONY: docker-build-nsm-init
+docker-build-nsm-init: docker-build-release
+	@${DOCKERBUILD} -t ${DOCKER_NSM_INIT} -f build/nsm-init/docker/Dockerfile .
+
+.PHONY: docker-build-nse
+docker-build-nse: docker-build-release
+	@${DOCKERBUILD} -t ${DOCKER_NSE} -f build/nse/docker/Dockerfile .
+
+#
+# Targets to push docker images
+#
+
+.PHONY: docker-login
+docker-ling:
+.PHONY: docker-push-netmesh
+	@docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+
+docker-push-netmesh:
+	@docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+	@export REPO=${DOCKER_NETMESH}
+	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
+	@docker tag ${REPO}:${COMMIT} ${REPO}:${TAG}
+	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push $REPO
+
+.PHONY: docker-push-simple-dataplane
+docker-push-simple-dataplane:
+	@export REPO=${DOCKER_SIMPLE_DATAPLANE}
+	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
+	@docker tag ${REPO}:${COMMIT} ${REPO}:${TAG}
+	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push $REPO
+
+.PHONY: docker-push-nsm-init
+docker-push-simple-nsm-init:
+	@export REPO=${DOCKER_NSM_INIT}
+	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
+	@docker tag ${REPO}:${COMMIT} ${REPO}:${TAG}
+	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push $REPO
+
+.PHONY: docker-push-nse
+docker-push-simple-nse:
+	@export REPO=${DOCKER_NSE}
+	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
+	@docker tag ${REPO}:${COMMIT} ${REPO}:${TAG}
+	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push $REPO

--- a/.nsm.mk
+++ b/.nsm.mk
@@ -16,8 +16,8 @@
 # and docker build infrastructure. It also contains the targets to build
 # and push Docker images
 
-DOCKER_NETMESH_TEST=networkservicemesh/nsm-daemon-test
-DOCKER_NETMESH=networkservicemesh/nsm-daemon
+DOCKER_NETMESH_TEST=networkservicemesh/netmesh-test
+DOCKER_NETMESH=networkservicemesh/netmesh
 DOCKER_SIMPLE_DATAPLANE=networkservicemesh/nsm-simple-dataplane
 DOCKER_NSM_INIT=networkservicemesh/nsm-init
 DOCKER_NSE=networkservicemesh/nse
@@ -55,10 +55,10 @@ docker-build-nse: docker-build-release
 #
 
 .PHONY: docker-login
-docker-ling:
-.PHONY: docker-push-netmesh
+docker-login:
 	@docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 
+.PHONY: docker-push-netmesh
 docker-push-netmesh:
 	@docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 	@export REPO=${DOCKER_NETMESH}

--- a/.nsm.mk
+++ b/.nsm.mk
@@ -59,7 +59,7 @@ docker-login:
 	@docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 
 .PHONY: docker-push-netmesh
-docker-push-netmesh:
+docker-push-netmesh: docker-login
 	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
 		export REPO=${DOCKER_NETMESH} ;\
 		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
@@ -68,7 +68,7 @@ docker-push-netmesh:
 	fi
 
 .PHONY: docker-push-simple-dataplane
-docker-push-simple-dataplane:
+docker-push-simple-dataplane: docker-login
 	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
 		export REPO=${DOCKER_SIMPLE_DATAPLANE} ;\
 		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
@@ -77,7 +77,7 @@ docker-push-simple-dataplane:
 	fi
 
 .PHONY: docker-push-nsm-init
-docker-push-simple-nsm-init:
+docker-push-simple-nsm-init: docker-login
 	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
 		export REPO=${DOCKER_NSM_INIT} ;\
 		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
@@ -86,7 +86,7 @@ docker-push-simple-nsm-init:
 	fi
 
 .PHONY: docker-push-nse
-docker-push-simple-nse:
+docker-push-simple-nse: docker-login
 	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
 		export REPO=${DOCKER_NSE} ;\
 		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\

--- a/.nsm.mk
+++ b/.nsm.mk
@@ -40,7 +40,7 @@ docker-build-netmesh: docker-build-release
 
 .PHONY: docker-build-simple-dataplane
 docker-build-simple-dataplane: docker-build-release
-	@docker build -t ${DOCKER_SIMPLE_DATAPLANE} -f build/simple-dataplane/docker/Dockerfile .
+	@${DOCKERBUILD} -t ${DOCKER_SIMPLE_DATAPLANE} -f build/simple-dataplane/docker/Dockerfile .
 
 .PHONY: docker-build-nsm-init
 docker-build-nsm-init: docker-build-release
@@ -60,33 +60,36 @@ docker-login:
 
 .PHONY: docker-push-netmesh
 docker-push-netmesh:
-	@docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-	@export REPO=${DOCKER_NETMESH}
-	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
-	@docker tag ${REPO}:${COMMIT} ${REPO}:${TAG}
-	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
-	@docker push $REPO
+	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
+		export REPO=${DOCKER_NETMESH} ;\
+		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
+		docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER} ;\
+		docker push $REPO
+	fi
 
 .PHONY: docker-push-simple-dataplane
 docker-push-simple-dataplane:
-	@export REPO=${DOCKER_SIMPLE_DATAPLANE}
-	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
-	@docker tag ${REPO}:${COMMIT} ${REPO}:${TAG}
-	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
-	@docker push $REPO
+	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
+		export REPO=${DOCKER_SIMPLE_DATAPLANE} ;\
+		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
+		docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER} ;\
+		docker push $REPO
+	fi
 
 .PHONY: docker-push-nsm-init
 docker-push-simple-nsm-init:
-	@export REPO=${DOCKER_NSM_INIT}
-	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
-	@docker tag ${REPO}:${COMMIT} ${REPO}:${TAG}
-	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
-	@docker push $REPO
+	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
+		export REPO=${DOCKER_NSM_INIT} ;\
+		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
+		docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER} ;\
+		docker push $REPO
+	fi
 
 .PHONY: docker-push-nse
 docker-push-simple-nse:
-	@export REPO=${DOCKER_NSE}
-	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
-	@docker tag ${REPO}:${COMMIT} ${REPO}:${TAG}
-	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
-	@docker push $REPO
+	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
+		export REPO=${DOCKER_NSE} ;\
+		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
+		docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER} ;\
+		docker push $REPO
+	fi

--- a/.nsm.mk
+++ b/.nsm.mk
@@ -18,7 +18,7 @@
 
 DOCKER_NETMESH_TEST=networkservicemesh/netmesh-test
 DOCKER_NETMESH=networkservicemesh/netmesh
-DOCKER_SIMPLE_DATAPLANE=networkservicemesh/nsm-simple-dataplane
+DOCKER_SIMPLE_DATAPLANE=networkservicemesh/simple-dataplane
 DOCKER_NSM_INIT=networkservicemesh/nsm-init
 DOCKER_NSE=networkservicemesh/nse
 DOCKER_RELEASE=networkservicemesh/release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 
 language: go
-service: 
+service:
   - docker
 
 go:
@@ -18,6 +18,18 @@ script:
 - make all
 - ./scripts/travis-integration-tests.sh minikube
 
+# We only want to push docker images on a push to master, not a pull request
+after_success:
+- if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then make docker-push ; fi
+
 notifications:
   irc:
     - "chat.freenode.net#networkservicemesh"
+
+# The below are the the username, email, and token used to push builds to Docker Hub
+env:
+  global:
+  - secure: NKZng9qbi/OU4nSfV+2ohSBt7qe8rxZTgTDBNlyoKV5UPiJB4ART9AHwkULngZsAM+dHzatjEGRyUn1OAlVWAfYw8nCGLg7zWKuAX4RMEYMTdEWDBM7Z3sJmQikENsdFRYmAJ0gQz+3Wf8CSLRni3VX+1olu9w58g7EFF/QfxVU65cMa7Pxt7EaZSaSvYpaZG8Njp2kpnlbaDrFlgr8B051cot02gtJXhDAC2ECaYsuj3WPAKIskDS00qz6kj+EH82ZKQf9M5+TblKjjzaxj1JuS7Y8ZmjrHXyKoaaOzoQ1zLHYkTNZeBvwIeDOPkSJokwvzZ06tFZN22KRxCLKeDLKhGixrkEV3HHll9RvM6DTa1/TKqKbjf17ACvri+AGhSrqyztwLsd5H+/fLzc55sXvF3SPu7kGjqdEifGX3Fakml1IFIAkTQQNbTkYZpju6Yi5zoJeBLn+x/lUWwVpYSlpDZktxYvg+j1ftPucl/WFpUqptxclCv/qACVPMw7IGEdZCIXvzhmG3jYP2bJC9H/rJK5MipEc8sYuCq2CbktlBoVGo5rChV/PZjKXTMlON3IabuT65An8Ev10n+bgWIcbA7eZF97npuHEGOGkGMWwZ5iKpqyzonTsQmdmSNsy/1me2V2Xwg2oyku0uQoTdsUXZSqllc27YOsuZkI8msmo=
+  - secure: d0G5U1W7ccAzEpRHO2uq3D0IOC8FhCDjb12yas6ozxI9zQ34yjL4xaY23XXokaTetulh79nBFp2Ro3JlN9f+qlBDNlPBQXwB79e7/dk8FD/1JG7zvRyhS1OiTCCCcDW4MeaioNqZkp1gjY5j8coi2eFqMXhteKcN0Speilj9aFw64s40o3mH4f6fVE8dYK4XLcr5Cr0llFcqHBaBWpMuRCrjaUvlrdeTvztkxl8mZUUbtjoiRoFCxMyRvKvnbkxluBU2D+brrUHA7iwYmFagBSMeq4XmnfuAE23Vp2UQfzZsKB20GLXI1lOhYrTKzSC/vRls2fKFIS6BDfT2AnSqMX1r+DVh7i4vtLudz6Etn09tFijmcSjpFiUFxa+FNnbMZgx+YyYOnvY4isRkTH2OsravHwOkg0MJrlQqAsMeqnLMjEETjyCxhMnB24aP2a8qHcPiZC5b/twCoouKc9dROPMr7EhDOFCNR8YaLZnoteIcIuMasMrVDoErj3/YvLsvtxcdMbsJBz4uYTVtTMMVvK8Pi634LTS/1d1KWV4rxk4PMuLypmmWA8WI5t8GG3XgPvBS8je9ozL7CEjhwsvsaW0FrlIzVGbofMWa2Juf6+xjBcRFVzzdK4sQivphZ6WocRmiQFb5M1s6PERdJxu538mv/tHbEzBlKwHMCQ/Wz+g=
+  - secure: AU8Q7N2EnQo4Mbls2LzzqSqFat8BRIGToUWdRz9jF+D4FDv28PH5XjYfN1qaZgs1+PjhHVltaWrqH+i4q4sOehVtUBCZtHp/lEMpbHjtWMtFpaMg7Vk9rfJ8zJAgXck936eNtH4Q8M+SKS2zb+g7p99pNIstUo6nTT4SRwykImlLlf3FevO04BET2uXD0cvSU/3iGGEqgCiE2ITi0YBlRJj95IlUCo8fdpo2sQgumIgRK5FU8zP+PBb07GFJI4YhazbNZT3NdYAIeFMTglg3Cg2h95A8vUBCblOgtBtwKxFubDucCLBPVxYPXj3juPYRT7XSODopusM9XrWoPXft8JicU0X0hDoXLfzc3s8r5J8/EbBex5/TPAtiSBBVxVD82eCdesEuo6YMqpnlmhJbx2rmrZkBaYqXuhYxITmKHfXOe0zsM8/n3e4W0VaM6Qh3RfVaxSdhO+P3tOX0F8Mpue2a6jvErrBhFmB8YZQTPmS5RN5mfb4qpL1KLSmod79uRoMOXTbO7VnHvBo6/JM9FFH10M0rAdbbpU0ozppQsPLN9Z2OOFJ6IcuB8d0PUxoprB4Xeh4J8urCha+VOSLQSlaTxP2a5EE7a5rGE/0MU/3s8l9E0B5xb3HAD0szHTNI5jh3hAPWgdwAFTJnXqUdczA5+HZcBcwm4RQ4kltRtN0=
+  - COMMIT=${TRAVIS_COMMIT::8}

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Pull in Docker image names
+include .nsm.mk
+
 GOPATH?=$(shell go env GOPATH)
 GOCMD=go
 GOFMT=${GOCMD} fmt
@@ -51,7 +54,7 @@ endif
 
 DOCKERBUILD=docker build ${HTTPBUILD} ${HTTPSBUILD}
 
-.PHONY: all check verify docker-build
+.PHONY: all check verify docker-build docker-push
 #
 # The all target is what is used by the travis-ci system to build the Docker images
 # which are used to run the code in each run.
@@ -64,31 +67,11 @@ check:
 verify:
 	@./scripts/verify-codegen.sh
 
+# Individual targets are found in .nsm.mk
 docker-build: docker-build-netmesh-test docker-build-netmesh docker-build-nsm-init docker-build-nse docker-build-simple-dataplane
 
-.PHONY: docker-build-netmesh-test
-docker-build-netmesh-test:
-	${DOCKERBUILD} -t networkservicemesh/netmesh-test -f build/nsm/docker/Test.Dockerfile .
-
-.PHONY: docker-build-release
-docker-build-release:
-	${DOCKERBUILD} -t networkservicemesh/release -f build/Dockerfile .
-
-.PHONY: docker-build-netmesh
-docker-build-netmesh: docker-build-release
-	${DOCKERBUILD} -t networkservicemesh/netmesh -f build/nsm/docker/Dockerfile .
-
-.PHONY: docker-build-simple-dataplane
-docker-build-simple-dataplane: docker-build-release
-	@docker build -t networkservicemesh/simple-dataplane -f build/simple-dataplane/docker/Dockerfile .
-
-.PHONY: docker-build-nsm-init
-docker-build-nsm-init: docker-build-release
-	${DOCKERBUILD} -t networkservicemesh/nsm-init -f build/nsm-init/docker/Dockerfile .
-
-.PHONY: docker-build-nse
-docker-build-nse: docker-build-release
-	${DOCKERBUILD} -t networkservicemesh/nse -f build/nse/docker/Dockerfile .
+# Individual targets are found in .nsm.mk
+docker-push: docker-login docker-push-netmesh docker-push-simple-dataplane docker-push-nsm-init docker-push-nse
 
 .PHONY: format deps generate install test test-race vet
 #

--- a/scripts/dev-integration-tests.sh
+++ b/scripts/dev-integration-tests.sh
@@ -26,9 +26,9 @@ then
     echo "Please build the image before running integration tests"
     exit 1
 fi
-if [ "x$(docker images|grep networkservicemesh/nsm-simple-dataplane)" == "x" ]
+if [ "x$(docker images|grep networkservicemesh/simple-dataplane)" == "x" ]
 then
-    echo "Docker image networkservicemesh/nsm-simple-dataplane not found"
+    echo "Docker image networkservicemesh/simple-dataplane not found"
     echo "Please build the image before running integration tests"
     exit 1
 fi

--- a/scripts/dev-integration-tests.sh
+++ b/scripts/dev-integration-tests.sh
@@ -24,25 +24,25 @@ if [ "x$(docker images|grep networkservicemesh/netmesh)" == "x" ]
 then
     echo "Docker image networkservicemesh/netmesh not found"
     echo "Please build the image before running integration tests"
-    exit 0
+    exit 1
 fi
 if [ "x$(docker images|grep networkservicemesh/nsm-simple-dataplane)" == "x" ]
 then
     echo "Docker image networkservicemesh/nsm-simple-dataplane not found"
     echo "Please build the image before running integration tests"
-    exit 0
+    exit 1
 fi
 if [ "x$(docker images|grep networkservicemesh/nsm-init)" == "x" ]
 then
     echo "Docker image networkservicemesh/nsm-init not found"
     echo "Please build the image before running integration tests"
-    exit 0
+    exit 1
 fi
 if [ "x$(docker images|grep networkservicemesh/nse)" == "x" ]
 then
     echo "Docker image networkservicemesh/nse not found"
     echo "Please build the image before running integration tests"
-    exit 0
+    exit 1
 fi
 
 # run_tests returns an error on failure

--- a/scripts/dev-integration-tests.sh
+++ b/scripts/dev-integration-tests.sh
@@ -26,9 +26,21 @@ then
     echo "Please build the image before running integration tests"
     exit 0
 fi
+if [ "x$(docker images|grep networkservicemesh/nsm-simple-dataplane)" == "x" ]
+then
+    echo "Docker image networkservicemesh/nsm-simple-dataplane not found"
+    echo "Please build the image before running integration tests"
+    exit 0
+fi
 if [ "x$(docker images|grep networkservicemesh/nsm-init)" == "x" ]
 then
     echo "Docker image networkservicemesh/nsm-init not found"
+    echo "Please build the image before running integration tests"
+    exit 0
+fi
+if [ "x$(docker images|grep networkservicemesh/nse)" == "x" ]
+then
+    echo "Docker image networkservicemesh/nse not found"
     echo "Please build the image before running integration tests"
     exit 0
 fi


### PR DESCRIPTION
Closes #186

This commit adds the ability to publish Docker Hub images into the
`networkservicemesh` Docker Hub organization. The following images are
published with this commit:

- networkservicemesh/nsm-daemon
- networkservicemesh/nsm-simple-dataplane
- networkservicemesh/nsm-init
- networkservicemesh/nse

Note that in addition, this commit revamps the Makefile a bit, moving
some complexity out into a .nsm.mk file which is then included by the
top-level Makefile.

Note also that for now, this commit makes use of my own Docker Hub login
information for build publishing. These are the secrets which are stored
in the .travis.yml file.

Signed-off-by: Kyle Mestery <mestery@mestery.com>