### PR TITLE
Ensure we update docker to the latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ go:
 
 go_import_path: github.com/ligato/networkservicemesh
 
+before_install:
+- ./.travis/update-docker.sh
+
 before_script:
 - sudo mount --make-rshared /
 - sudo mount --make-rshared /sys

--- a/.travis/update-docker.sh
+++ b/.travis/update-docker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+sudo apt update
+sudo apt install --only-upgrade docker-ce -y
+
+docker info


### PR DESCRIPTION
This PR ensures our travis nodes are running the latest version of
Docker before we run tests on them.

Signed-off-by: Kyle Mestery <mestery@mestery.com>