### PR TITLE
Cleanup the Makefile

### DIFF
--- a/.nsm.mk
+++ b/.nsm.mk
@@ -1,0 +1,52 @@
+# Copyright (c) 2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file includes definitions for Docker images used by the Makefile
+# and docker build infrastructure. It also contains the targets to build
+# and push Docker images
+
+DOCKER_NETMESH_TEST=networkservicemesh/netmesh-test
+DOCKER_NETMESH=networkservicemesh/netmesh
+DOCKER_SIMPLE_DATAPLANE=networkservicemesh/simple-dataplane
+DOCKER_NSM_INIT=networkservicemesh/nsm-init
+DOCKER_NSE=networkservicemesh/nse
+DOCKER_RELEASE=networkservicemesh/release
+
+#
+# Targets to build docker images
+#
+.PHONY: docker-build-netmesh-test
+docker-build-netmesh-test:
+	@${DOCKERBUILD} -t ${DOCKER_NETMESH_TEST} -f build/nsm/docker/Test.Dockerfile .
+
+.PHONY: docker-build-release
+docker-build-release:
+	@${DOCKERBUILD} -t ${DOCKER_RELEASE} -f build/Dockerfile .
+
+.PHONY: docker-build-netmesh
+docker-build-netmesh: docker-build-release
+	@${DOCKERBUILD} -t ${DOCKER_NETMESH} -f build/nsm/docker/Dockerfile .
+
+.PHONY: docker-build-simple-dataplane
+docker-build-simple-dataplane: docker-build-release
+	@${DOCKERBUILD} -t ${DOCKER_SIMPLE_DATAPLANE} -f build/simple-dataplane/docker/Dockerfile .
+
+.PHONY: docker-build-nsm-init
+docker-build-nsm-init: docker-build-release
+	@${DOCKERBUILD} -t ${DOCKER_NSM_INIT} -f build/nsm-init/docker/Dockerfile .
+
+.PHONY: docker-build-nse
+docker-build-nse: docker-build-release
+	@${DOCKERBUILD} -t ${DOCKER_NSE} -f build/nse/docker/Dockerfile .
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 
 language: go
-service: 
+service:
   - docker
 
 go:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Pull in Docker image names
+include .nsm.mk
+
 GOPATH?=$(shell go env GOPATH)
 GOCMD=go
 GOFMT=${GOCMD} fmt
@@ -64,31 +67,8 @@ check:
 verify:
 	@./scripts/verify-codegen.sh
 
+# Individual targets are found in .nsm.mk
 docker-build: docker-build-netmesh-test docker-build-netmesh docker-build-nsm-init docker-build-nse docker-build-simple-dataplane
-
-.PHONY: docker-build-netmesh-test
-docker-build-netmesh-test:
-	${DOCKERBUILD} -t networkservicemesh/netmesh-test -f build/nsm/docker/Test.Dockerfile .
-
-.PHONY: docker-build-release
-docker-build-release:
-	${DOCKERBUILD} -t networkservicemesh/release -f build/Dockerfile .
-
-.PHONY: docker-build-netmesh
-docker-build-netmesh: docker-build-release
-	${DOCKERBUILD} -t networkservicemesh/netmesh -f build/nsm/docker/Dockerfile .
-
-.PHONY: docker-build-simple-dataplane
-docker-build-simple-dataplane: docker-build-release
-	@docker build -t networkservicemesh/simple-dataplane -f build/simple-dataplane/docker/Dockerfile .
-
-.PHONY: docker-build-nsm-init
-docker-build-nsm-init: docker-build-release
-	${DOCKERBUILD} -t networkservicemesh/nsm-init -f build/nsm-init/docker/Dockerfile .
-
-.PHONY: docker-build-nse
-docker-build-nse: docker-build-release
-	${DOCKERBUILD} -t networkservicemesh/nse -f build/nse/docker/Dockerfile .
 
 .PHONY: format deps generate install test test-race vet
 #

--- a/scripts/dev-integration-tests.sh
+++ b/scripts/dev-integration-tests.sh
@@ -24,13 +24,25 @@ if [ "x$(docker images|grep networkservicemesh/netmesh)" == "x" ]
 then
     echo "Docker image networkservicemesh/netmesh not found"
     echo "Please build the image before running integration tests"
-    exit 0
+    exit 1
+fi
+if [ "x$(docker images|grep networkservicemesh/simple-dataplane)" == "x" ]
+then
+    echo "Docker image networkservicemesh/simple-dataplane not found"
+    echo "Please build the image before running integration tests"
+    exit 1
 fi
 if [ "x$(docker images|grep networkservicemesh/nsm-init)" == "x" ]
 then
     echo "Docker image networkservicemesh/nsm-init not found"
     echo "Please build the image before running integration tests"
-    exit 0
+    exit 1
+fi
+if [ "x$(docker images|grep networkservicemesh/nse)" == "x" ]
+then
+    echo "Docker image networkservicemesh/nse not found"
+    echo "Please build the image before running integration tests"
+    exit 1
 fi
 
 # run_tests returns an error on failure


### PR DESCRIPTION
This commit cleans the Makefile up a bit by splitting out the lower
level portions into .nse.mk.

Signed-off-by: Kyle Mestery <mestery@mestery.com>