### PR TITLE
Add a k8sclient plugin

### DIFF
--- a/plugins/crd/options.go
+++ b/plugins/crd/options.go
@@ -15,6 +15,7 @@
 package crd
 
 import (
+	"github.com/ligato/networkservicemesh/plugins/k8sclient"
 	"github.com/ligato/networkservicemesh/plugins/objectstore"
 
 	"github.com/ligato/networkservicemesh/plugins/handler"
@@ -63,6 +64,7 @@ func UseDeps(deps *Deps) Option {
 		d.Log = deps.Log
 		d.Handler = deps.Handler
 		d.ObjectStore = deps.ObjectStore
+		d.K8sclient = deps.K8sclient
 		d.KubeConfig = deps.KubeConfig
 	}
 }
@@ -83,6 +85,9 @@ func DefaultDeps() Option {
 		}
 		if d.ObjectStore == nil {
 			d.ObjectStore = objectstore.SharedPlugin()
+		}
+		if d.K8sclient == nil {
+			d.K8sclient = k8sclient.SharedPlugin()
 		}
 		if d.KubeConfig == "" {
 			cmd := command.RootCmd()

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -17,7 +17,6 @@
 package crd
 
 import (
-	"fmt"
 	"reflect"
 	"sync"
 	"time"
@@ -27,16 +26,14 @@ import (
 	"github.com/ligato/networkservicemesh/utils/registry"
 
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/ligato/cn-infra/health/statuscheck"
 	"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1"
 	client "github.com/ligato/networkservicemesh/pkg/client/clientset/versioned"
 	factory "github.com/ligato/networkservicemesh/pkg/client/informers/externalversions"
 	"github.com/ligato/networkservicemesh/plugins/handler"
+	"github.com/ligato/networkservicemesh/plugins/k8sclient"
 	"github.com/ligato/networkservicemesh/plugins/logger"
 	"github.com/ligato/networkservicemesh/plugins/objectstore"
 	"github.com/ligato/networkservicemesh/utils/command"
@@ -50,13 +47,11 @@ type Plugin struct {
 	idempotent.Impl
 	Deps
 
-	pluginStopCh    chan struct{}
-	wg              sync.WaitGroup
-	k8sClientConfig *rest.Config
-	k8sClientset    *kubernetes.Clientset
-	apiclientset    *apiextcs.Clientset
-	crdClient       client.Interface
-	StatusMonitor   statuscheck.StatusReader
+	pluginStopCh  chan struct{}
+	wg            sync.WaitGroup
+	apiclientset  *apiextcs.Clientset
+	crdClient     client.Interface
+	StatusMonitor statuscheck.StatusReader
 
 	// These can be used to stop all the informers, as well as control loops
 	// within the application.
@@ -83,6 +78,7 @@ type Deps struct {
 	KubeConfig  string `empty_value_ok:"true"`
 	Handler     handler.API
 	ObjectStore objectstore.Interface
+	K8sclient   k8sclient.Interface
 }
 
 // Init builds K8s client-set based on the supplied kubeconfig and initializes
@@ -99,15 +95,6 @@ func (plugin *Plugin) init() error {
 	plugin.KubeConfig = command.RootCmd().Flags().Lookup(KubeConfigFlagName).Value.String()
 
 	plugin.Log.WithField("kubeconfig", plugin.KubeConfig).Info("Loading kubernetes client config")
-	plugin.k8sClientConfig, err = clientcmd.BuildConfigFromFlags("", plugin.KubeConfig)
-	if err != nil {
-		return fmt.Errorf("Failed to build kubernetes client config: %s", err)
-	}
-
-	plugin.k8sClientset, err = kubernetes.NewForConfig(plugin.k8sClientConfig)
-	if err != nil {
-		return fmt.Errorf("failed to build kubernetes client: %s", err)
-	}
 
 	plugin.stopChNS = make(chan struct{})
 	plugin.stopChNSC = make(chan struct{})
@@ -169,13 +156,13 @@ func (plugin *Plugin) afterInit() error {
 	var crdname string
 
 	// Create clientset and create our CRD, this only needs to run once
-	plugin.apiclientset, err = apiextcs.NewForConfig(plugin.k8sClientConfig)
+	plugin.apiclientset, err = apiextcs.NewForConfig(plugin.K8sclient.GetClientConfig())
 	if err != nil {
 		panic(err.Error())
 	}
 
 	// Create an instance of our own API client
-	plugin.crdClient, err = client.NewForConfig(plugin.k8sClientConfig)
+	plugin.crdClient, err = client.NewForConfig(plugin.K8sclient.GetClientConfig())
 	if err != nil {
 		plugin.Log.Errorf("Error creating CRD client: %s", err.Error())
 		panic(err.Error())

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -78,7 +78,7 @@ type Deps struct {
 	KubeConfig  string `empty_value_ok:"true"`
 	Handler     handler.API
 	ObjectStore objectstore.Interface
-	K8sclient   k8sclient.Interface
+	K8sclient   k8sclient.API
 }
 
 // Init builds K8s client-set based on the supplied kubeconfig and initializes

--- a/plugins/finalizer/finalizer_plugin.go
+++ b/plugins/finalizer/finalizer_plugin.go
@@ -65,7 +65,7 @@ type Deps struct {
 	// Kubeconfig with k8s cluster address and access credentials to use.
 	KubeConfig  string `empty_value_ok:"true"`
 	ObjectStore objectstore.Interface
-	K8sclient   k8sclient.Interface
+	K8sclient   k8sclient.API
 }
 
 // Init builds K8s client-set based on the supplied kubeconfig and initializes

--- a/plugins/finalizer/finalizer_queue.go
+++ b/plugins/finalizer/finalizer_queue.go
@@ -106,7 +106,7 @@ func cleanUpNSE(plugin *Plugin, pod *v1.Pod) error {
 	}
 	// Step 5 removing finalizer and allowing k8s to delete pod, if pod does not have a finalizer,
 	// this call is just no-op.
-	finalizerutils.RemovePodFinalizer(plugin.k8sClientset, pod.ObjectMeta.Name, pod.ObjectMeta.Namespace)
+	finalizerutils.RemovePodFinalizer(plugin.K8sclient.GetClientset(), pod.ObjectMeta.Name, pod.ObjectMeta.Namespace)
 
 	return nil
 }
@@ -120,7 +120,7 @@ func cleanUpNSMClient(plugin *Plugin, pod *v1.Pod) error {
 		plugin.Log.Errorf("failed to clean up pod %s/%s dataplane with error: %+v, please review dataplane controller log if further debugging is required",
 			pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, err)
 	}
-	finalizerutils.RemovePodFinalizer(plugin.k8sClientset, pod.ObjectMeta.Name, pod.ObjectMeta.Namespace)
+	finalizerutils.RemovePodFinalizer(plugin.K8sclient.GetClientset(), pod.ObjectMeta.Name, pod.ObjectMeta.Namespace)
 
 	return nil
 }

--- a/plugins/finalizer/options.go
+++ b/plugins/finalizer/options.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"sync"
 
+	"github.com/ligato/networkservicemesh/plugins/k8sclient"
 	"github.com/ligato/networkservicemesh/plugins/objectstore"
 
 	"github.com/ligato/networkservicemesh/plugins/logger"
@@ -87,6 +88,7 @@ func UseDeps(deps *Deps) Option {
 		d.Name = deps.Name
 		d.Log = deps.Log
 		d.ObjectStore = deps.ObjectStore
+		d.K8sclient = deps.K8sclient
 		d.KubeConfig = deps.KubeConfig
 	}
 }
@@ -104,6 +106,9 @@ func DefaultDeps() Option {
 		}
 		if d.ObjectStore == nil {
 			d.ObjectStore = objectstore.SharedPlugin()
+		}
+		if d.K8sclient == nil {
+			d.K8sclient = k8sclient.SharedPlugin()
 		}
 		if d.KubeConfig == "" {
 			cmd := command.RootCmd()

--- a/plugins/handler/plugin_impl_handler.go
+++ b/plugins/handler/plugin_impl_handler.go
@@ -15,7 +15,6 @@
 package handler
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/ligato/networkservicemesh/utils/helper/deptools"
@@ -24,12 +23,10 @@ import (
 
 	"github.com/ligato/networkservicemesh/utils/idempotent"
 
+	"github.com/ligato/networkservicemesh/plugins/k8sclient"
 	"github.com/ligato/networkservicemesh/plugins/logger"
 	"github.com/ligato/networkservicemesh/plugins/objectstore"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Plugin is the base plugin object for this CRD handler
@@ -37,9 +34,7 @@ type Plugin struct {
 	idempotent.Impl
 	Deps
 
-	pluginStopCh    chan struct{}
-	k8sClientConfig *rest.Config
-	k8sClientset    *kubernetes.Clientset
+	pluginStopCh chan struct{}
 }
 
 // Deps defines dependencies of netmesh plugin.
@@ -49,6 +44,7 @@ type Deps struct {
 	Cmd         *cobra.Command
 	KubeConfig  string `empty_value_ok:"true"` // Fetch kubeconfig file from --kube-config
 	ObjectStore objectstore.Interface
+	K8sclient   k8sclient.Interface
 }
 
 // Init builds K8s client-set based on the supplied kubeconfig and initializes
@@ -65,15 +61,6 @@ func (p *Plugin) init() error {
 	}
 
 	p.Log.WithField("kubeconfig", p.KubeConfig).Info("Loading kubernetes client config")
-	p.k8sClientConfig, err = clientcmd.BuildConfigFromFlags("", p.KubeConfig)
-	if err != nil {
-		return fmt.Errorf("Failed to build kubernetes client config: %s", err)
-	}
-
-	p.k8sClientset, err = kubernetes.NewForConfig(p.k8sClientConfig)
-	if err != nil {
-		return fmt.Errorf("failed to build kubernetes client: %s", err)
-	}
 
 	return nil
 }

--- a/plugins/handler/plugin_impl_handler.go
+++ b/plugins/handler/plugin_impl_handler.go
@@ -44,7 +44,7 @@ type Deps struct {
 	Cmd         *cobra.Command
 	KubeConfig  string `empty_value_ok:"true"` // Fetch kubeconfig file from --kube-config
 	ObjectStore objectstore.Interface
-	K8sclient   k8sclient.Interface
+	K8sclient   k8sclient.API
 }
 
 // Init builds K8s client-set based on the supplied kubeconfig and initializes

--- a/plugins/k8sclient/api.go
+++ b/plugins/k8sclient/api.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Interface is the interface to a k8sclient plugin
-type Interface interface {
+type API interface {
 	GetClientConfig() *rest.Config
 	GetClientset() *kubernetes.Clientset
 }

--- a/plugins/k8sclient/api.go
+++ b/plugins/k8sclient/api.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient
+
+import (
+	"github.com/ligato/networkservicemesh/plugins/idempotent"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// Interface is the interface to a k8sclient plugin
+type Interface interface {
+	GetClientConfig() *rest.Config
+	GetClientset() *kubernetes.Clientset
+}
+
+// PluginAPI for k8sclient
+type PluginAPI interface {
+	idempotent.PluginAPI
+}

--- a/plugins/k8sclient/deps.go
+++ b/plugins/k8sclient/deps.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient
+
+import (
+	"github.com/ligato/networkservicemesh/plugins/logger"
+)
+
+// Deps defines dependencies of k8sclient plugin.
+type Deps struct {
+	Name string
+	Log  logger.FieldLoggerPlugin
+	// Kubeconfig with k8s cluster address and access credentials to use.
+	KubeConfig string `empty_value_ok:"true"`
+}

--- a/plugins/k8sclient/docs.go
+++ b/plugins/k8sclient/docs.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient

--- a/plugins/k8sclient/impl.go
+++ b/plugins/k8sclient/impl.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/ligato/networkservicemesh/utils/command"
+	"github.com/ligato/networkservicemesh/utils/helper/deptools"
+	"github.com/ligato/networkservicemesh/utils/helper/plugintools"
+	"github.com/ligato/networkservicemesh/utils/idempotent"
+	"github.com/ligato/networkservicemesh/utils/registry"
+)
+
+// Plugin for k8sclient
+type Plugin struct {
+	idempotent.Impl
+	Deps
+
+	k8sClientConfig *rest.Config
+	k8sClientset    *kubernetes.Clientset
+}
+
+// Init Plugin
+func (p *Plugin) Init() error {
+	return p.Impl.IdempotentInit(plugintools.LoggingInitFunc(p.Log, p, p.init))
+}
+
+func (p *Plugin) init() error {
+	var err error
+
+	p.KubeConfig = command.RootCmd().Flags().Lookup(KubeConfigFlagName).Value.String()
+
+	p.Log.WithField("kubeconfig", p.KubeConfig).Info("Loading kubernetes client config")
+	p.k8sClientConfig, err = clientcmd.BuildConfigFromFlags("", p.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("Failed to build kubernetes client config: %s", err)
+	}
+
+	p.k8sClientset, err = kubernetes.NewForConfig(p.k8sClientConfig)
+	if err != nil {
+		return fmt.Errorf("failed to build kubernetes client: %s", err)
+	}
+
+	return nil
+}
+
+// Close Plugin
+func (p *Plugin) Close() error {
+	return p.Impl.IdempotentClose(plugintools.LoggingCloseFunc(p.Log, p, p.close))
+}
+
+func (p *Plugin) close() error {
+	registry.Shared().Delete(p)
+	return deptools.Close(p)
+}
+
+// GetClientConfig returns a pointer to our rest.Config object
+func (p *Plugin) GetClientConfig() *rest.Config {
+	return p.k8sClientConfig
+}
+
+// GetClientset returns a pointer to our kubernetes.Clientset object
+func (p *Plugin) GetClientset() *kubernetes.Clientset {
+	return p.k8sClientset
+}

--- a/plugins/k8sclient/options_test.go
+++ b/plugins/k8sclient/options_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient_test
+
+import (
+	"testing"
+
+	"github.com/ligato/networkservicemesh/plugins/k8sclient"
+	"github.com/ligato/networkservicemesh/utils/helper/deptools"
+	"github.com/ligato/networkservicemesh/utils/registry/testsuites"
+	. "github.com/onsi/gomega"
+)
+
+func TestSharedPlugin(t *testing.T) {
+	RegisterTestingT(t)
+	plugin1 := k8sclient.SharedPlugin()
+	Expect(plugin1).NotTo(BeNil())
+	plugin2 := k8sclient.SharedPlugin()
+	Expect(plugin2 == plugin1).To(BeTrue())
+	Expect(deptools.Check(plugin1)).To(Succeed())
+}
+
+func TestNewPluginNotShared(t *testing.T) {
+	RegisterTestingT(t)
+	plugin1 := k8sclient.NewPlugin()
+	Expect(plugin1).NotTo(BeNil())
+	plugin2 := k8sclient.SharedPlugin()
+	Expect(plugin2 == plugin1).ToNot(BeTrue())
+	Expect(deptools.Check(plugin1)).To(Succeed())
+	Expect(deptools.Check(plugin2)).To(Succeed())
+}
+
+func TestSharedPluginRemoveOnClose(t *testing.T) {
+	RegisterTestingT(t)
+	plugin1 := k8sclient.SharedPlugin()
+	plugin1.Init()
+	plugin1.Close()
+	plugin2 := k8sclient.SharedPlugin()
+	Expect(plugin2 == plugin1).ToNot(BeTrue())
+	Expect(deptools.Check(plugin1)).To(Succeed())
+	Expect(deptools.Check(plugin2)).To(Succeed())
+}
+
+func TestNonDefaultName(t *testing.T) {
+	RegisterTestingT(t)
+	name := "foo"
+	plugin := k8sclient.NewPlugin(k8sclient.UseDeps(&k8sclient.Deps{Name: name}))
+	Expect(plugin).NotTo(BeNil())
+	Expect(deptools.Check(plugin)).To(Succeed())
+}
+
+func TestWithRegistry(t *testing.T) {
+	name := "foo"
+	p1 := k8sclient.NewPlugin()
+	p2 := k8sclient.NewPlugin()
+	p3 := k8sclient.NewPlugin(k8sclient.UseDeps(&k8sclient.Deps{Name: name}))
+	testsuites.SuiteRegistry(t, p1, p2, p3)
+}

--- a/plugins/k8sclient/options_test.go
+++ b/plugins/k8sclient/options_test.go
@@ -23,36 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestSharedPlugin(t *testing.T) {
-	RegisterTestingT(t)
-	plugin1 := k8sclient.SharedPlugin()
-	Expect(plugin1).NotTo(BeNil())
-	plugin2 := k8sclient.SharedPlugin()
-	Expect(plugin2 == plugin1).To(BeTrue())
-	Expect(deptools.Check(plugin1)).To(Succeed())
-}
-
-func TestNewPluginNotShared(t *testing.T) {
-	RegisterTestingT(t)
-	plugin1 := k8sclient.NewPlugin()
-	Expect(plugin1).NotTo(BeNil())
-	plugin2 := k8sclient.SharedPlugin()
-	Expect(plugin2 == plugin1).ToNot(BeTrue())
-	Expect(deptools.Check(plugin1)).To(Succeed())
-	Expect(deptools.Check(plugin2)).To(Succeed())
-}
-
-func TestSharedPluginRemoveOnClose(t *testing.T) {
-	RegisterTestingT(t)
-	plugin1 := k8sclient.SharedPlugin()
-	plugin1.Init()
-	plugin1.Close()
-	plugin2 := k8sclient.SharedPlugin()
-	Expect(plugin2 == plugin1).ToNot(BeTrue())
-	Expect(deptools.Check(plugin1)).To(Succeed())
-	Expect(deptools.Check(plugin2)).To(Succeed())
-}
-
 func TestNonDefaultName(t *testing.T) {
 	RegisterTestingT(t)
 	name := "foo"


### PR DESCRIPTION
This plugin provides access to rest.Config and kubernetes.Clientset
in a common location. Today, many plugins define their own usage of
these as follows:

        k8sClientConfig *rest.Config
        k8sClientset    *kubernetes.Clientset

This is inefficient as it replicates this code across many different
plugins.

Signed-off-by: Kyle Mestery <mestery@mestery.com>