### PR TITLE
Push images to Docker Hub on each merge to master

### DIFF
--- a/.nsm.mk
+++ b/.nsm.mk
@@ -60,36 +60,32 @@ docker-login:
 
 .PHONY: docker-push-netmesh
 docker-push-netmesh: docker-login
-	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
-		export REPO=${DOCKER_NETMESH} ;\
-		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
-		docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER} ;\
-		docker push $REPO ;\
-	fi
+	@export REPO=${DOCKER_NETMESH}
+	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
+	@docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG}
+	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push $REPO
 
 .PHONY: docker-push-simple-dataplane
 docker-push-simple-dataplane: docker-login
-	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
-		export REPO=${DOCKER_SIMPLE_DATAPLANE} ;\
-		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
-		docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER} ;\
-		docker push $REPO ;\
-	fi
+	@export REPO=${DOCKER_SIMPLE_DATAPLANE}
+	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
+	@docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG}
+	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push $REPO
 
 .PHONY: docker-push-nsm-init
 docker-push-simple-nsm-init: docker-login
-	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
-		export REPO=${DOCKER_NSM_INIT} ;\
-		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
-		docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER} ;\
-		docker push $REPO ;\
-	fi
+	@export REPO=${DOCKER_NSM_INIT}
+	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
+	@docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG}
+	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push $REPO
 
 .PHONY: docker-push-nse
 docker-push-simple-nse: docker-login
-	@if [ "x${TRAVIS_TAG}" != "x" ] ; then \
-		export REPO=${DOCKER_NSE} ;\
-		docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG} ;\
-		docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER} ;\
-		docker push $REPO ;\
-	fi
+	@export REPO=${DOCKER_NSE}
+	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
+	@docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG}
+	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push $REPO


### PR DESCRIPTION
For now, we should push images to Docker Hub each time we merge to master.
Eventually we'll want to do this based on tags or branches, but given the
velocity of development, I think it's prudent to push with each merge.

Signed-off-by: Kyle Mestery <mestery@mestery.com>