### PR TITLE
Conditionally tag the docker images with ${COMMIT}

### DIFF
--- a/.nsm.mk
+++ b/.nsm.mk
@@ -32,50 +32,44 @@ DOCKER_RELEASE=networkservicemesh/release
 #
 .PHONY: docker-build-netmesh-test
 docker-build-netmesh-test:
-	@if [ "x${COMMIT}" == "x" ] ; then \
-		${DOCKERBUILD} -t ${DOCKER_NETMESH_TEST} -f build/Dockerfile.nsm-test . ;\
-	else \
-		${DOCKERBUILD} -t ${DOCKER_NETMESH_TEST}:${COMMIT} -f build/Dockerfile.nsm-test . ;\
+	@${DOCKERBUILD} -t ${DOCKER_NETMESH_TEST} -f build/Dockerfile.nsm-test .
+	@if [ "x${COMMIT}" != "x" ] ; then \
+		docker tag ${DOCKER_NETMESH_TEST} ${DOCKER_NETMESH_TEST}:${COMMIT} ;\
 	fi
 
 .PHONY: docker-build-release
 docker-build-release:
-	@if [ "x${COMMIT}" == "x" ] ; then \
-		${DOCKERBUILD} -t ${DOCKER_RELEASE} -f build/Dockerfile . ;\
-	else \
-		${DOCKERBUILD} -t ${DOCKER_RELEASE}:${COMMIT} -f build/Dockerfile . ;\
+	@${DOCKERBUILD} -t ${DOCKER_RELEASE} -f build/Dockerfile .
+	@if [ "x${COMMIT}" != "x" ] ; then \
+		docker tag ${DOCKER_RELEASE} ${DOCKER_RELEASE}:${COMMIT} ;\
 	fi
 
 .PHONY: docker-build-netmesh
 docker-build-netmesh: docker-build-release
-	@if [ "x${COMMIT}" == "x" ] ; then \
-		${DOCKERBUILD} -t ${DOCKER_NETMESH} -f build/Dockerfile.nsm . ;\
-	else \
-		${DOCKERBUILD} -t ${DOCKER_NETMESH}:${COMMIT} -f build/Dockerfile.nsm . ;\
+	@${DOCKERBUILD} -t ${DOCKER_NETMESH} -f build/Dockerfile.nsm .
+	@if [ "x${COMMIT}" != "x" ] ; then \
+		docker tag ${DOCKER_NETMESH} ${DOCKER_NETMESH}:${COMMIT} ;\
 	fi
 
 .PHONY: docker-build-simple-dataplane
 docker-build-simple-dataplane: docker-build-release
-	@if [ "x${COMMIT}" == "x" ] ; then \
-		${DOCKERBUILD} -t ${DOCKER_SIMPLE_DATAPLANE} -f build/Dockerfile.simple-dataplane . ;\
-	else \
-		${DOCKERBUILD} -t ${DOCKER_SIMPLE_DATAPLANE}:${COMMIT} -f build/Dockerfile.simple-dataplane . ;\
+	@${DOCKERBUILD} -t ${DOCKER_SIMPLE_DATAPLANE} -f build/Dockerfile.simple-dataplane .
+	@if [ "x${COMMIT}" != "x" ] ; then \
+		docker tag ${DOCKER_SIMPLE_DATAPLANE} ${DOCKER_SIMPLE_DATAPLANE}:${COMMIT} ;\
 	fi
 
 .PHONY: docker-build-nsm-init
 docker-build-nsm-init: docker-build-release
-	@if [ "x${COMMIT}" == "x" ] ; then \
-		${DOCKERBUILD} -t ${DOCKER_NSM_INIT} -f build/Dockerfile.nsm-init . ;\
-	else \
-		${DOCKERBUILD} -t ${DOCKER_NSM_INIT}:${COMMIT} -f build/Dockerfile.nsm-init . ;\
+	@${DOCKERBUILD} -t ${DOCKER_NSM_INIT} -f build/Dockerfile.nsm-init .
+	@if [ "x${COMMIT}" != "x" ] ; then \
+		docker tag ${DOCKER_NSM_INIT} ${DOCKER_NSM_INIT}:${COMMIT} ;\
 	fi
 
 .PHONY: docker-build-nse
 docker-build-nse: docker-build-release
-	@if [ "x${COMMIT}" == "x" ] ; then \
-		${DOCKERBUILD} -t ${DOCKER_NSE} -f build/Dockerfile.nse . ;\
-	else \
-		${DOCKERBUILD} -t ${DOCKER_NSE}:${COMMIT} -f build/Dockerfile.nse . ;\
+	@${DOCKERBUILD} -t ${DOCKER_NSE} -f build/Dockerfile.nse .
+	@if [ "x${COMMIT}" != "x" ] ; then \
+		docker tag ${DOCKER_NSE} ${DOCKER_NSE}:${COMMIT} ;\
 	fi
 
 #

--- a/.nsm.mk
+++ b/.nsm.mk
@@ -26,34 +26,63 @@ DOCKER_RELEASE=networkservicemesh/release
 #
 # Targets to build docker images
 #
+# NOTE: ${COMMIT} is set in .travis.yml from the first 8 bytes of
+# ${TRAVIS_COMMIT}. Thus, for travis-ci builds, we tag the Docker images
+# with both the name and this first 8 bytes of the commit hash.
+#
 .PHONY: docker-build-netmesh-test
 docker-build-netmesh-test:
-	@${DOCKERBUILD} -t ${DOCKER_NETMESH_TEST} -f build/Dockerfile.nsm-test .
+	@if [ "x${COMMIT}" == "x" ] ; then \
+		${DOCKERBUILD} -t ${DOCKER_NETMESH_TEST} -f build/Dockerfile.nsm-test . ;\
+	else \
+		${DOCKERBUILD} -t ${DOCKER_NETMESH_TEST}:${COMMIT} -f build/Dockerfile.nsm-test . ;\
+	fi
 
 .PHONY: docker-build-release
 docker-build-release:
-	@${DOCKERBUILD} -t ${DOCKER_RELEASE} -f build/Dockerfile .
+	@if [ "x${COMMIT}" == "x" ] ; then \
+		${DOCKERBUILD} -t ${DOCKER_RELEASE} -f build/Dockerfile . ;\
+	else \
+		${DOCKERBUILD} -t ${DOCKER_RELEASE}:${COMMIT} -f build/Dockerfile . ;\
+	fi
 
 .PHONY: docker-build-netmesh
 docker-build-netmesh: docker-build-release
-	@${DOCKERBUILD} -t ${DOCKER_NETMESH} -f build/Dockerfile.nsm .
+	@if [ "x${COMMIT}" == "x" ] ; then \
+		${DOCKERBUILD} -t ${DOCKER_NETMESH} -f build/Dockerfile.nsm . ;\
+	else \
+		${DOCKERBUILD} -t ${DOCKER_NETMESH}:${COMMIT} -f build/Dockerfile.nsm . ;\
+	fi
 
 .PHONY: docker-build-simple-dataplane
 docker-build-simple-dataplane: docker-build-release
-	@${DOCKERBUILD} -t ${DOCKER_SIMPLE_DATAPLANE} -f build/Dockerfile.simple-dataplane .
+	@if [ "x${COMMIT}" == "x" ] ; then \
+		${DOCKERBUILD} -t ${DOCKER_SIMPLE_DATAPLANE} -f build/Dockerfile.simple-dataplane . ;\
+	else \
+		${DOCKERBUILD} -t ${DOCKER_SIMPLE_DATAPLANE}:${COMMIT} -f build/Dockerfile.simple-dataplane . ;\
+	fi
 
 .PHONY: docker-build-nsm-init
 docker-build-nsm-init: docker-build-release
-	@${DOCKERBUILD} -t ${DOCKER_NSM_INIT} -f build/Dockerfile.nsm-init .
+	@if [ "x${COMMIT}" == "x" ] ; then \
+		${DOCKERBUILD} -t ${DOCKER_NSM_INIT} -f build/Dockerfile.nsm-init . ;\
+	else \
+		${DOCKERBUILD} -t ${DOCKER_NSM_INIT}:${COMMIT} -f build/Dockerfile.nsm-init . ;\
+	fi
 
 .PHONY: docker-build-nse
 docker-build-nse: docker-build-release
-	@${DOCKERBUILD} -t ${DOCKER_NSE} -f build/Dockerfile.nse .
+	@if [ "x${COMMIT}" == "x" ] ; then \
+		${DOCKERBUILD} -t ${DOCKER_NSE} -f build/Dockerfile.nse . ;\
+	else \
+		${DOCKERBUILD} -t ${DOCKER_NSE}:${COMMIT} -f build/Dockerfile.nse . ;\
+	fi
 
 #
 # Targets to push docker images
 #
-
+# NOTE: These assume that ${COMMIT} is set and are meant to be called from travis-ci only.
+#
 .PHONY: docker-login
 docker-login:
 	@echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ before_script:
 - sudo mount --make-rshared /var/run
 
 script:
-- make all
-- ./scripts/travis-integration-tests.sh minikube
+- make all && ./scripts/travis-integration-tests.sh minikube
 
 # We only want to push docker images on a push to master, not a pull request
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# We want to use bash
+SHELL:=/bin/bash
+
 # Pull in Docker image names
 include .nsm.mk
 


### PR DESCRIPTION
If we're building from travis-ci, tag the images with ${COMMIT},
which comes from ${TRAVIS_COMMIT}.

Without this commit, the `docker push` commands were failing from travis-ci because they were expecting the image to be tagged with ${COMMIT}.

Signed-off-by: Kyle Mestery <mestery@mestery.com>