### PR TITLE
Correct environment variable usage when pushing docker images

### DIFF
--- a/.nsm.mk
+++ b/.nsm.mk
@@ -83,32 +83,28 @@ docker-login:
 
 .PHONY: docker-push-netmesh
 docker-push-netmesh: docker-login
-	@export REPO=${DOCKER_NETMESH}
 	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
-	@docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG}
-	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
-	@docker push $REPO
+	@docker tag ${DOCKER_NETMESH}:${COMMIT} ${DOCKER_NETMESH}:${TAG}
+	@docker tag ${DOCKER_NETMESH}:${COMMIT} ${DOCKER_NETMESH}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push ${DOCKER_NETMESH}
 
 .PHONY: docker-push-simple-dataplane
 docker-push-simple-dataplane: docker-login
-	@export REPO=${DOCKER_SIMPLE_DATAPLANE}
 	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
-	@docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG}
-	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
-	@docker push $REPO
+	@docker tag ${DOCKER_SIMPLE_DATAPLANE}:${COMMIT} ${DOCKER_SIMPLE_DATAPLANE}:${TAG}
+	@docker tag ${DOCKER_SIMPLE_DATAPLANE}:${COMMIT} ${DOCKER_SIMPLE_DATAPLANE}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push ${DOCKER_SIMPLE_DATAPLANE}
 
 .PHONY: docker-push-nsm-init
 docker-push-simple-nsm-init: docker-login
-	@export REPO=${DOCKER_NSM_INIT}
 	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
-	@docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG}
-	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
-	@docker push $REPO
+	@docker tag ${DOCKER_NSM_INIT}:${COMMIT} ${DOCKER_NSM_INIT}:${TAG}
+	@docker tag ${DOCKER_NSM_INIT}:${COMMIT} ${DOCKER_NSM_INIT}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push ${DOCKER_NSM_INIT}
 
 .PHONY: docker-push-nse
 docker-push-simple-nse: docker-login
-	@export REPO=${DOCKER_NSE}
 	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
-	@docker tag ${REPO}:${COMMIT} ${REPO}:${TRAVIS_TAG}
-	@docker tag ${REPO}:${COMMIT} ${REPO}:travis-${TRAVIS_BUILD_NUMBER}
-	@docker push $REPO
+	@docker tag ${DOCKER_NSE}:${COMMIT} ${DOCKER_NSE}:${TAG}
+	@docker tag ${DOCKER_NSE}:${COMMIT} ${DOCKER_NSE}:travis-${TRAVIS_BUILD_NUMBER}
+	@docker push ${DOCKER_NSE}


### PR DESCRIPTION
In a Makefile, it turns out it's tricky to set environment variables in a
target and then use them. This was being done in .nse.mk by setting $REPO
to whatever repository was being worked on, and it was failing: it was
never set.

It turns out this is an unnecessary optimization, so simply removing this
should allow the `docker push` operations to succeed.

Signed-off-by: Kyle Mestery <mestery@mestery.com>