### PR TITLE
Change where the TAG variable is defined

### DIFF
--- a/.nsm.mk
+++ b/.nsm.mk
@@ -83,28 +83,24 @@ docker-login:
 
 .PHONY: docker-push-netmesh
 docker-push-netmesh: docker-login
-	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
 	@docker tag ${DOCKER_NETMESH}:${COMMIT} ${DOCKER_NETMESH}:${TAG}
 	@docker tag ${DOCKER_NETMESH}:${COMMIT} ${DOCKER_NETMESH}:travis-${TRAVIS_BUILD_NUMBER}
 	@docker push ${DOCKER_NETMESH}
 
 .PHONY: docker-push-simple-dataplane
 docker-push-simple-dataplane: docker-login
-	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
 	@docker tag ${DOCKER_SIMPLE_DATAPLANE}:${COMMIT} ${DOCKER_SIMPLE_DATAPLANE}:${TAG}
 	@docker tag ${DOCKER_SIMPLE_DATAPLANE}:${COMMIT} ${DOCKER_SIMPLE_DATAPLANE}:travis-${TRAVIS_BUILD_NUMBER}
 	@docker push ${DOCKER_SIMPLE_DATAPLANE}
 
 .PHONY: docker-push-nsm-init
 docker-push-simple-nsm-init: docker-login
-	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
 	@docker tag ${DOCKER_NSM_INIT}:${COMMIT} ${DOCKER_NSM_INIT}:${TAG}
 	@docker tag ${DOCKER_NSM_INIT}:${COMMIT} ${DOCKER_NSM_INIT}:travis-${TRAVIS_BUILD_NUMBER}
 	@docker push ${DOCKER_NSM_INIT}
 
 .PHONY: docker-push-nse
 docker-push-simple-nse: docker-login
-	@export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi`
 	@docker tag ${DOCKER_NSE}:${COMMIT} ${DOCKER_NSE}:${TAG}
 	@docker tag ${DOCKER_NSE}:${COMMIT} ${DOCKER_NSE}:travis-${TRAVIS_BUILD_NUMBER}
 	@docker push ${DOCKER_NSE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 
 # We only want to push docker images on a push to master, not a pull request
 after_success:
-- if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then make docker-push ; fi
+- if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi` && make docker-push ; fi
 
 notifications:
   irc:


### PR DESCRIPTION
Move this into .travis.yml instead of in each `docker push` Makefile
target. This removes duplication, but more importantly these variables
need to be defined outside the Makefile targets themselves.

Signed-off-by: Kyle Mestery <mestery@mestery.com>