### PR TITLE
Fix embarrassing spelling error in Makefile targets

### DIFF
--- a/.nsm.mk
+++ b/.nsm.mk
@@ -94,13 +94,13 @@ docker-push-simple-dataplane: docker-login
 	docker push ${DOCKER_SIMPLE_DATAPLANE}
 
 .PHONY: docker-push-nsm-init
-docker-push-simple-nsm-init: docker-login
+docker-push-nsm-init: docker-login
 	docker tag ${DOCKER_NSM_INIT}:${COMMIT} ${DOCKER_NSM_INIT}:${TAG}
 	docker tag ${DOCKER_NSM_INIT}:${COMMIT} ${DOCKER_NSM_INIT}:travis-${TRAVIS_BUILD_NUMBER}
 	docker push ${DOCKER_NSM_INIT}
 
 .PHONY: docker-push-nse
-docker-push-simple-nse: docker-login
+docker-push-nse: docker-login
 	docker tag ${DOCKER_NSE}:${COMMIT} ${DOCKER_NSE}:${TAG}
 	docker tag ${DOCKER_NSE}:${COMMIT} ${DOCKER_NSE}:travis-${TRAVIS_BUILD_NUMBER}
 	docker push ${DOCKER_NSE}


### PR DESCRIPTION
This was preventing `docker push` from working for all repositories
because the Makefile targets it was incorrectly trying to run had
.PHONY entries but no actual entries.

*sigh*

Signed-off-by: Kyle Mestery <mestery@mestery.com>