### PR TITLE
Dump more information for each travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ go_import_path: github.com/ligato/networkservicemesh
 
 before_install:
 - ./.travis/update-docker.sh
+- make travis
 
 before_script:
 - sudo mount --make-rshared /

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,21 @@ test-race:
 vet:
 	${GOVET} ${GOVETTARGETS}
 
+# Travis
+.PHONY: travis
+travis:
+	@echo "=> TRAVIS: $$TRAVIS_BUILD_STAGE_NAME"
+	@echo "Build: #$$TRAVIS_BUILD_NUMBER ($$TRAVIS_BUILD_ID)"
+	@echo "Job: #$$TRAVIS_JOB_NUMBER ($$TRAVIS_JOB_ID)"
+	@echo "AllowFailure: $$TRAVIS_ALLOW_FAILURE TestResult: $$TRAVIS_TEST_RESULT"
+	@echo "Type: $$TRAVIS_EVENT_TYPE PullRequest: $$TRAVIS_PULL_REQUEST"
+	@echo "Repo: $$TRAVIS_REPO_SLUG Branch: $$TRAVIS_BRANCH"
+	@echo "Commit: $$TRAVIS_COMMIT"
+	@echo "$$TRAVIS_COMMIT_MESSAGE"
+	@echo "Range: $$TRAVIS_COMMIT_RANGE"
+	@echo "Files:"
+	@echo "$$(git diff --name-only $$TRAVIS_COMMIT_RANGE)"
+
 # Test target to debug proxy issues
 checkproxy:
 	echo "HTTPBUILD=${HTTPBUILD} HTTPSBUILD=${HTTPSBUILD}"


### PR DESCRIPTION
Similar to the Ligato vpp-agent [1], add the dumping of a bunch of useful
information for each travis-ci run.

[1] https://github.com/ligato/vpp-agent/blob/pantheon-dev/Makefile#L217-L228

Signed-off-by: Kyle Mestery <mestery@mestery.com>