### PR TITLE
Fixing add/delete multiple entries bug

### DIFF
--- a/controllers/sriov-controller/dpapi-controller.go
+++ b/controllers/sriov-controller/dpapi-controller.go
@@ -60,16 +60,21 @@ type serviceInstanceController struct {
 	server    *grpc.Server
 }
 
-func newServiceInstanceController() *serviceInstanceController {
+func newServiceInstanceController(configCh chan configMessage, stopCh, doneCh chan struct{}) *serviceInstanceController {
 	si := serviceInstance{
-		vfs: map[string]*VF{},
+		vfs:      map[string]*VF{},
+		configCh: configCh,
 	}
-	return &serviceInstanceController{si, notRegistered, sync.RWMutex{}, "", "",
-		make(chan struct{},
-			updateChannelBufferSize),
-		make(chan struct{}),
-		make(chan struct{}),
-		nil}
+	sic := &serviceInstanceController{
+		serviceInstance: si,
+		regState:        notRegistered,
+		regUpdateCh:     make(chan struct{}, updateChannelBufferSize),
+		regStopCh:       stopCh,
+		regDoneCh:       doneCh,
+	}
+	sic.RWMutex = sync.RWMutex{}
+
+	return sic
 }
 
 // Run starts Network Service instance and wait for configuration messages
@@ -104,8 +109,10 @@ func (s *serviceInstanceController) Run() {
 func (s *serviceInstanceController) processAddVF(msg configMessage) {
 	logrus.Infof("Network Service instance: %s, adding new VF, PCI address: %s", msg.vf.NetworkService, msg.pciAddr)
 	if s.regState == notRegistered {
+		s.Lock()
 		logrus.Infof("service instance controller for %s has not yet been registered with kubelet, initiating registration process", msg.vf.NetworkService)
 		s.regState = registrationInProgress
+		s.Unlock()
 		go s.startDevicePlugin(msg)
 	}
 	s.Lock()
@@ -120,8 +127,8 @@ func (s *serviceInstanceController) processAddVF(msg configMessage) {
 func (s *serviceInstanceController) processDeleteVF(msg configMessage) {
 	logrus.Infof("Network Service instance: %s, delete VF, PCI address: %s", msg.vf.NetworkService, msg.pciAddr)
 	s.Lock()
+	defer s.Unlock()
 	delete(s.vfs, msg.pciAddr)
-	s.Unlock()
 	// Sending ListAndWatch notification of an update
 	s.regUpdateCh <- struct{}{}
 }
@@ -236,7 +243,8 @@ func (s *serviceInstanceController) ListAndWatch(e *pluginapi.Empty, d pluginapi
 		case <-s.regStopCh:
 			logrus.Infof("ListAndWatch of Network Service %s received shut down signal.", s.networkServiceName)
 			// Informing kubelet that VFs which belong to network service are not useable now
-			d.Send(&pluginapi.ListAndWatchResponse{Devices: s.buildDeviceList(pluginapi.Unhealthy)})
+			d.Send(&pluginapi.ListAndWatchResponse{
+				Devices: []*pluginapi.Device{}})
 			close(s.regDoneCh)
 			return nil
 		case <-s.regUpdateCh:

--- a/controllers/sriov-controller/service-controller.go
+++ b/controllers/sriov-controller/service-controller.go
@@ -89,14 +89,14 @@ func (s *serviceController) processAdd(msg configMessage) {
 		}
 		s.sriovNetServices[msg.vf.NetworkService] = si
 		// Instantiating Service Instance controller
-		sic := newServiceInstanceController()
-		sic.configCh = si.configCh
-		sic.stopCh = si.stopCh
-		sic.doneCh = si.doneCh
+		sic := newServiceInstanceController(si.configCh, si.stopCh, si.doneCh)
 		go sic.Run()
 	}
-	// Network Service instance already exists, just need to inform about new VF
+	// Network Service instance already exists, just need to add to VFS map and inform about new VF
+	s.Lock()
+	defer s.Unlock()
 	nsi := s.sriovNetServices[msg.vf.NetworkService]
+	nsi.vfs[msg.pciAddr] = &msg.vf
 	nsi.configCh <- msg
 }
 


### PR DESCRIPTION
Adding VF function was missing actual add to the map code, as a result number of VFs in the map was reported incorrectly. Deleting entries from configmap wilt `kubectl edit configmap blah` resulted the whole network service to be stopped advertising. This PR fixes this issue and add some robustness in terms of concurrent access of data structures.
  
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>