### PR TITLE
Adding UnRegister api call

### DIFF
--- a/.api_violations.report
+++ b/.api_violations.report
@@ -1,0 +1,6 @@
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkService,NetworkServiceName
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkServiceEndpoint,NetworkServiceName
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkServiceEndpoint,NetworkServiceHost
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkServiceEndpoint,NseProviderName
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkServiceEndpoint,SocketLocation
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkServiceEndpoint,LocalMechanisms

--- a/pkg/apis/networkservicemesh.io/v1/openapi_generated.go
+++ b/pkg/apis/networkservicemesh.io/v1/openapi_generated.go
@@ -31,6 +31,8 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1.NetworkServiceEndpoint":     schema_pkg_apis_networkservicemeshio_v1_NetworkServiceEndpoint(ref),
 		"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1.NetworkServiceEndpointList": schema_pkg_apis_networkservicemeshio_v1_NetworkServiceEndpointList(ref),
 		"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1.NetworkServiceList":         schema_pkg_apis_networkservicemeshio_v1_NetworkServiceList(ref),
+		"github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh.NetworkService":                          schema_pkg_nsm_apis_netmesh_NetworkService(ref),
+		"github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh.NetworkServiceEndpoint":                  schema_pkg_nsm_apis_netmesh_NetworkServiceEndpoint(ref),
 	}
 }
 
@@ -211,5 +213,72 @@ func schema_pkg_apis_networkservicemeshio_v1_NetworkServiceList(ref common.Refer
 		},
 		Dependencies: []string{
 			"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1.NetworkService", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+	}
+}
+
+func schema_pkg_nsm_apis_netmesh_NetworkService(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"network_service_name": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_pkg_nsm_apis_netmesh_NetworkServiceEndpoint(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"network_service_name": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"network_service_host": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"nse_provider_name": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"socket_location": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"local_mechanisms": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/ligato/networkservicemesh/pkg/nsm/apis/common.LocalMechanism"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"github.com/ligato/networkservicemesh/pkg/nsm/apis/common.LocalMechanism"},
 	}
 }

--- a/pkg/nsm/apis/common/common.pb.go
+++ b/pkg/nsm/apis/common/common.pb.go
@@ -125,8 +125,8 @@ func (m *Empty) XXX_DiscardUnknown() {
 var xxx_messageInfo_Empty proto.InternalMessageInfo
 
 type LocalMechanism struct {
-	Type                 LocalMechanismType `protobuf:"varint,1,opt,name=type,enum=common.LocalMechanismType" json:"type,omitempty"`
-	Parameters           map[string]string  `protobuf:"bytes,2,rep,name=parameters" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Type                 LocalMechanismType `protobuf:"varint,1,opt,name=type,proto3,enum=common.LocalMechanismType" json:"type,omitempty"`
+	Parameters           map[string]string  `protobuf:"bytes,2,rep,name=parameters,proto3" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -171,8 +171,8 @@ func (m *LocalMechanism) GetParameters() map[string]string {
 }
 
 type RemoteMechanism struct {
-	Type                 RemoteMechanismType `protobuf:"varint,1,opt,name=type,enum=common.RemoteMechanismType" json:"type,omitempty"`
-	Parameters           map[string]string   `protobuf:"bytes,2,rep,name=parameters" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Type                 RemoteMechanismType `protobuf:"varint,1,opt,name=type,proto3,enum=common.RemoteMechanismType" json:"type,omitempty"`
+	Parameters           map[string]string   `protobuf:"bytes,2,rep,name=parameters,proto3" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
 	XXX_unrecognized     []byte              `json:"-"`
 	XXX_sizecache        int32               `json:"-"`

--- a/pkg/nsm/apis/dataplaneinterface/dataplaneinterface.pb.go
+++ b/pkg/nsm/apis/dataplaneinterface/dataplaneinterface.pb.go
@@ -27,7 +27,7 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 // Message sent by dataplane module informing NSM of any changes in its
 // operations parameters or constraints
 type DataplaneUpdate struct {
-	RemoteMechanism      []*common.RemoteMechanism `protobuf:"bytes,1,rep,name=remote_mechanism,json=remoteMechanism" json:"remote_mechanism,omitempty"`
+	RemoteMechanism      []*common.RemoteMechanism `protobuf:"bytes,1,rep,name=remote_mechanism,json=remoteMechanism,proto3" json:"remote_mechanism,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
 	XXX_unrecognized     []byte                    `json:"-"`
 	XXX_sizecache        int32                     `json:"-"`
@@ -123,8 +123,7 @@ func (x *dataplaneOperationsUpdateDataplaneClient) Recv() (*DataplaneUpdate, err
 	return m, nil
 }
 
-// Server API for DataplaneOperations service
-
+// DataplaneOperationsServer is the server API for DataplaneOperations service.
 type DataplaneOperationsServer interface {
 	UpdateDataplane(*common.Empty, DataplaneOperations_UpdateDataplaneServer) error
 }

--- a/pkg/nsm/apis/dataplaneregistrar/dataplaneregistrar.pb.go
+++ b/pkg/nsm/apis/dataplaneregistrar/dataplaneregistrar.pb.go
@@ -28,10 +28,10 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 // to advertise itself and inform NSM about the location of the dataplane socket
 // and its initially supported parameters.
 type DataplaneRegistrationRequest struct {
-	DataplaneName        string                    `protobuf:"bytes,1,opt,name=dataplane_name,json=dataplaneName" json:"dataplane_name,omitempty"`
-	DataplaneSocket      string                    `protobuf:"bytes,2,opt,name=dataplane_socket,json=dataplaneSocket" json:"dataplane_socket,omitempty"`
-	LocalMechanisms      []*common.LocalMechanism  `protobuf:"bytes,3,rep,name=local_mechanisms,json=localMechanisms" json:"local_mechanisms,omitempty"`
-	RemoteMechanisms     []*common.RemoteMechanism `protobuf:"bytes,4,rep,name=remote_mechanisms,json=remoteMechanisms" json:"remote_mechanisms,omitempty"`
+	DataplaneName        string                    `protobuf:"bytes,1,opt,name=dataplane_name,json=dataplaneName,proto3" json:"dataplane_name,omitempty"`
+	DataplaneSocket      string                    `protobuf:"bytes,2,opt,name=dataplane_socket,json=dataplaneSocket,proto3" json:"dataplane_socket,omitempty"`
+	LocalMechanisms      []*common.LocalMechanism  `protobuf:"bytes,3,rep,name=local_mechanisms,json=localMechanisms,proto3" json:"local_mechanisms,omitempty"`
+	RemoteMechanisms     []*common.RemoteMechanism `protobuf:"bytes,4,rep,name=remote_mechanisms,json=remoteMechanisms,proto3" json:"remote_mechanisms,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
 	XXX_unrecognized     []byte                    `json:"-"`
 	XXX_sizecache        int32                     `json:"-"`
@@ -41,7 +41,7 @@ func (m *DataplaneRegistrationRequest) Reset()         { *m = DataplaneRegistrat
 func (m *DataplaneRegistrationRequest) String() string { return proto.CompactTextString(m) }
 func (*DataplaneRegistrationRequest) ProtoMessage()    {}
 func (*DataplaneRegistrationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_dataplaneregistrar_c17f4642d0a039b8, []int{0}
+	return fileDescriptor_dataplaneregistrar_a19b7e336169d2fb, []int{0}
 }
 func (m *DataplaneRegistrationRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DataplaneRegistrationRequest.Unmarshal(m, b)
@@ -90,7 +90,7 @@ func (m *DataplaneRegistrationRequest) GetRemoteMechanisms() []*common.RemoteMec
 }
 
 type DataplaneRegistrationReply struct {
-	Registered           bool     `protobuf:"varint,1,opt,name=registered" json:"registered,omitempty"`
+	Registered           bool     `protobuf:"varint,1,opt,name=registered,proto3" json:"registered,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -100,7 +100,7 @@ func (m *DataplaneRegistrationReply) Reset()         { *m = DataplaneRegistratio
 func (m *DataplaneRegistrationReply) String() string { return proto.CompactTextString(m) }
 func (*DataplaneRegistrationReply) ProtoMessage()    {}
 func (*DataplaneRegistrationReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_dataplaneregistrar_c17f4642d0a039b8, []int{1}
+	return fileDescriptor_dataplaneregistrar_a19b7e336169d2fb, []int{1}
 }
 func (m *DataplaneRegistrationReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DataplaneRegistrationReply.Unmarshal(m, b)
@@ -127,9 +127,89 @@ func (m *DataplaneRegistrationReply) GetRegistered() bool {
 	return false
 }
 
+// DataplaneUnRegistrationRequest is sent by the dataplane to NSM
+// to remove itself from the list of available dataplanes.
+type DataplaneUnRegistrationRequest struct {
+	DataplaneName        string   `protobuf:"bytes,1,opt,name=dataplane_name,json=dataplaneName,proto3" json:"dataplane_name,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DataplaneUnRegistrationRequest) Reset()         { *m = DataplaneUnRegistrationRequest{} }
+func (m *DataplaneUnRegistrationRequest) String() string { return proto.CompactTextString(m) }
+func (*DataplaneUnRegistrationRequest) ProtoMessage()    {}
+func (*DataplaneUnRegistrationRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_dataplaneregistrar_a19b7e336169d2fb, []int{2}
+}
+func (m *DataplaneUnRegistrationRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DataplaneUnRegistrationRequest.Unmarshal(m, b)
+}
+func (m *DataplaneUnRegistrationRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DataplaneUnRegistrationRequest.Marshal(b, m, deterministic)
+}
+func (dst *DataplaneUnRegistrationRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DataplaneUnRegistrationRequest.Merge(dst, src)
+}
+func (m *DataplaneUnRegistrationRequest) XXX_Size() int {
+	return xxx_messageInfo_DataplaneUnRegistrationRequest.Size(m)
+}
+func (m *DataplaneUnRegistrationRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_DataplaneUnRegistrationRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DataplaneUnRegistrationRequest proto.InternalMessageInfo
+
+func (m *DataplaneUnRegistrationRequest) GetDataplaneName() string {
+	if m != nil {
+		return m.DataplaneName
+	}
+	return ""
+}
+
+type DataplaneUnRegistrationReply struct {
+	UnRegistered         bool     `protobuf:"varint,1,opt,name=un_registered,json=unRegistered,proto3" json:"un_registered,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DataplaneUnRegistrationReply) Reset()         { *m = DataplaneUnRegistrationReply{} }
+func (m *DataplaneUnRegistrationReply) String() string { return proto.CompactTextString(m) }
+func (*DataplaneUnRegistrationReply) ProtoMessage()    {}
+func (*DataplaneUnRegistrationReply) Descriptor() ([]byte, []int) {
+	return fileDescriptor_dataplaneregistrar_a19b7e336169d2fb, []int{3}
+}
+func (m *DataplaneUnRegistrationReply) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DataplaneUnRegistrationReply.Unmarshal(m, b)
+}
+func (m *DataplaneUnRegistrationReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DataplaneUnRegistrationReply.Marshal(b, m, deterministic)
+}
+func (dst *DataplaneUnRegistrationReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DataplaneUnRegistrationReply.Merge(dst, src)
+}
+func (m *DataplaneUnRegistrationReply) XXX_Size() int {
+	return xxx_messageInfo_DataplaneUnRegistrationReply.Size(m)
+}
+func (m *DataplaneUnRegistrationReply) XXX_DiscardUnknown() {
+	xxx_messageInfo_DataplaneUnRegistrationReply.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DataplaneUnRegistrationReply proto.InternalMessageInfo
+
+func (m *DataplaneUnRegistrationReply) GetUnRegistered() bool {
+	if m != nil {
+		return m.UnRegistered
+	}
+	return false
+}
+
 func init() {
 	proto.RegisterType((*DataplaneRegistrationRequest)(nil), "dataplaneregistrar.DataplaneRegistrationRequest")
 	proto.RegisterType((*DataplaneRegistrationReply)(nil), "dataplaneregistrar.DataplaneRegistrationReply")
+	proto.RegisterType((*DataplaneUnRegistrationRequest)(nil), "dataplaneregistrar.DataplaneUnRegistrationRequest")
+	proto.RegisterType((*DataplaneUnRegistrationReply)(nil), "dataplaneregistrar.DataplaneUnRegistrationReply")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -199,8 +279,7 @@ func (x *dataplaneRegistrationRequestLivenessClient) Recv() (*common.Empty, erro
 	return m, nil
 }
 
-// Server API for DataplaneRegistration service
-
+// DataplaneRegistrationServer is the server API for DataplaneRegistration service.
 type DataplaneRegistrationServer interface {
 	RequestDataplaneRegistration(context.Context, *DataplaneRegistrationRequest) (*DataplaneRegistrationReply, error)
 	// RequestLiveness is a stream initiated by NSM to inform the dataplane that NSM is still alive and
@@ -277,31 +356,99 @@ var _DataplaneRegistration_serviceDesc = grpc.ServiceDesc{
 	Metadata: "dataplaneregistrar.proto",
 }
 
-func init() {
-	proto.RegisterFile("dataplaneregistrar.proto", fileDescriptor_dataplaneregistrar_c17f4642d0a039b8)
+// DataplaneUnRegistrationClient is the client API for DataplaneUnRegistration service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+type DataplaneUnRegistrationClient interface {
+	RequestDataplaneUnRegistration(ctx context.Context, in *DataplaneUnRegistrationRequest, opts ...grpc.CallOption) (*DataplaneUnRegistrationReply, error)
 }
 
-var fileDescriptor_dataplaneregistrar_c17f4642d0a039b8 = []byte{
-	// 332 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x92, 0x4d, 0x4b, 0xf3, 0x40,
-	0x10, 0xc7, 0xd9, 0xa7, 0x0f, 0xa2, 0x23, 0xb5, 0x75, 0x41, 0x0d, 0xa1, 0x48, 0x29, 0x08, 0xf5,
-	0x92, 0x94, 0xf6, 0xea, 0x45, 0x68, 0x6f, 0xd5, 0x43, 0xfc, 0x00, 0x65, 0x9b, 0x0e, 0xe9, 0xd2,
-	0xec, 0x6e, 0xdc, 0xd9, 0x56, 0x7a, 0xf3, 0x1b, 0xfa, 0x79, 0xbc, 0x49, 0xd3, 0xa4, 0x2f, 0x18,
-	0x05, 0x4f, 0x61, 0xfe, 0xf3, 0x9f, 0x5f, 0xe6, 0x65, 0xc1, 0x9b, 0x09, 0x27, 0xb2, 0x54, 0x68,
-	0xb4, 0x98, 0x48, 0x72, 0x56, 0xd8, 0x20, 0xb3, 0xc6, 0x19, 0xce, 0xbf, 0x67, 0xfc, 0x51, 0x22,
-	0xdd, 0x7c, 0x39, 0x0d, 0x62, 0xa3, 0xc2, 0x54, 0x26, 0xc2, 0x99, 0x50, 0xa3, 0x7b, 0x33, 0x76,
-	0x41, 0x68, 0x57, 0x32, 0x46, 0x85, 0x34, 0x0f, 0xb3, 0x45, 0x12, 0x6a, 0x52, 0xa1, 0xc8, 0x24,
-	0x85, 0xb1, 0x51, 0xca, 0xe8, 0xe2, 0xb3, 0x45, 0x77, 0x3e, 0x19, 0xb4, 0x86, 0x25, 0x3d, 0x2a,
-	0xe8, 0x4e, 0x1a, 0x1d, 0xe1, 0xeb, 0x12, 0xc9, 0xf1, 0x3b, 0xb8, 0xd8, 0xfd, 0x7d, 0xa2, 0x85,
-	0x42, 0x8f, 0xb5, 0x59, 0xf7, 0x2c, 0xaa, 0xef, 0xd4, 0x67, 0xa1, 0x90, 0xdf, 0x43, 0x73, 0x6f,
-	0x23, 0x13, 0x2f, 0xd0, 0x79, 0xff, 0x72, 0x63, 0x63, 0xa7, 0xbf, 0xe4, 0x32, 0x7f, 0x84, 0x66,
-	0x6a, 0x62, 0x91, 0x4e, 0x14, 0xc6, 0x73, 0xa1, 0x25, 0x29, 0xf2, 0x6a, 0xed, 0x5a, 0xf7, 0xbc,
-	0x7f, 0x1d, 0x14, 0xbd, 0x8d, 0x37, 0xf9, 0xa7, 0x32, 0x1d, 0x35, 0xd2, 0xa3, 0x98, 0xf8, 0x10,
-	0x2e, 0x2d, 0x2a, 0xe3, 0xf0, 0x90, 0xf1, 0x3f, 0x67, 0xdc, 0x94, 0x8c, 0x28, 0x37, 0xec, 0x21,
-	0x4d, 0x7b, 0x2c, 0x50, 0xe7, 0x01, 0xfc, 0x1f, 0x46, 0xcf, 0xd2, 0x35, 0xbf, 0x05, 0xd8, 0x6e,
-	0x1b, 0x2d, 0xce, 0xf2, 0xa1, 0x4f, 0xa3, 0x03, 0xa5, 0xff, 0xc1, 0xe0, 0xaa, 0xb2, 0x9c, 0xbf,
-	0x33, 0x68, 0x15, 0xeb, 0xab, 0x36, 0xf4, 0x82, 0x8a, 0x53, 0xff, 0x76, 0x05, 0x3f, 0xf8, 0x43,
-	0xc5, 0xa6, 0xf9, 0x01, 0x34, 0x8a, 0xd2, 0xb1, 0x5c, 0xa1, 0x46, 0x22, 0x5e, 0x2f, 0x17, 0x33,
-	0x52, 0x99, 0x5b, 0xfb, 0xc7, 0x61, 0x97, 0xf5, 0xd8, 0xf4, 0x24, 0x7f, 0x12, 0x83, 0xaf, 0x00,
-	0x00, 0x00, 0xff, 0xff, 0x79, 0x6d, 0x96, 0x8b, 0x89, 0x02, 0x00, 0x00,
+type dataplaneUnRegistrationClient struct {
+	cc *grpc.ClientConn
+}
+
+func NewDataplaneUnRegistrationClient(cc *grpc.ClientConn) DataplaneUnRegistrationClient {
+	return &dataplaneUnRegistrationClient{cc}
+}
+
+func (c *dataplaneUnRegistrationClient) RequestDataplaneUnRegistration(ctx context.Context, in *DataplaneUnRegistrationRequest, opts ...grpc.CallOption) (*DataplaneUnRegistrationReply, error) {
+	out := new(DataplaneUnRegistrationReply)
+	err := c.cc.Invoke(ctx, "/dataplaneregistrar.DataplaneUnRegistration/RequestDataplaneUnRegistration", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DataplaneUnRegistrationServer is the server API for DataplaneUnRegistration service.
+type DataplaneUnRegistrationServer interface {
+	RequestDataplaneUnRegistration(context.Context, *DataplaneUnRegistrationRequest) (*DataplaneUnRegistrationReply, error)
+}
+
+func RegisterDataplaneUnRegistrationServer(s *grpc.Server, srv DataplaneUnRegistrationServer) {
+	s.RegisterService(&_DataplaneUnRegistration_serviceDesc, srv)
+}
+
+func _DataplaneUnRegistration_RequestDataplaneUnRegistration_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DataplaneUnRegistrationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DataplaneUnRegistrationServer).RequestDataplaneUnRegistration(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/dataplaneregistrar.DataplaneUnRegistration/RequestDataplaneUnRegistration",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DataplaneUnRegistrationServer).RequestDataplaneUnRegistration(ctx, req.(*DataplaneUnRegistrationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+var _DataplaneUnRegistration_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "dataplaneregistrar.DataplaneUnRegistration",
+	HandlerType: (*DataplaneUnRegistrationServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "RequestDataplaneUnRegistration",
+			Handler:    _DataplaneUnRegistration_RequestDataplaneUnRegistration_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "dataplaneregistrar.proto",
+}
+
+func init() {
+	proto.RegisterFile("dataplaneregistrar.proto", fileDescriptor_dataplaneregistrar_a19b7e336169d2fb)
+}
+
+var fileDescriptor_dataplaneregistrar_a19b7e336169d2fb = []byte{
+	// 396 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x53, 0x4d, 0xab, 0xd3, 0x40,
+	0x14, 0x65, 0x7c, 0x22, 0x7a, 0xb5, 0xb6, 0x0e, 0xe8, 0x0b, 0xe1, 0x51, 0x1e, 0x11, 0xa1, 0x6e,
+	0x92, 0x92, 0x6e, 0xdd, 0x88, 0x2d, 0x6e, 0xaa, 0x8b, 0x88, 0xeb, 0x32, 0x4d, 0x2f, 0xe9, 0xd0,
+	0xcc, 0x4c, 0x9c, 0x99, 0x54, 0xba, 0x73, 0xe5, 0x0f, 0xf1, 0x0f, 0xf9, 0x7b, 0xdc, 0x49, 0xd2,
+	0x24, 0xfd, 0x4a, 0x0b, 0x7d, 0xab, 0x30, 0xe7, 0x9e, 0x7b, 0x72, 0xce, 0xbd, 0x33, 0xe0, 0x2c,
+	0x98, 0x65, 0x59, 0xca, 0x24, 0x6a, 0x4c, 0xb8, 0xb1, 0x9a, 0x69, 0x3f, 0xd3, 0xca, 0x2a, 0x4a,
+	0x4f, 0x2b, 0xee, 0x24, 0xe1, 0x76, 0x99, 0xcf, 0xfd, 0x58, 0x89, 0x20, 0xe5, 0x09, 0xb3, 0x2a,
+	0x90, 0x68, 0x7f, 0x2a, 0xbd, 0x32, 0xa8, 0xd7, 0x3c, 0x46, 0x81, 0x66, 0x19, 0x64, 0xab, 0x24,
+	0x90, 0x46, 0x04, 0x2c, 0xe3, 0x26, 0x88, 0x95, 0x10, 0x4a, 0x56, 0x9f, 0xad, 0xb4, 0xf7, 0x8f,
+	0xc0, 0xdd, 0xb8, 0x56, 0x8f, 0x2a, 0x75, 0xcb, 0x95, 0x8c, 0xf0, 0x47, 0x8e, 0xc6, 0xd2, 0x77,
+	0xf0, 0xb2, 0xf9, 0xfb, 0x4c, 0x32, 0x81, 0x0e, 0xb9, 0x27, 0x83, 0x67, 0x51, 0xa7, 0x41, 0xbf,
+	0x32, 0x81, 0xf4, 0x3d, 0xf4, 0x76, 0x34, 0xa3, 0xe2, 0x15, 0x5a, 0xe7, 0x51, 0x49, 0xec, 0x36,
+	0xf8, 0xb7, 0x12, 0xa6, 0x1f, 0xa1, 0x97, 0xaa, 0x98, 0xa5, 0x33, 0x81, 0xf1, 0x92, 0x49, 0x6e,
+	0x84, 0x71, 0x6e, 0xee, 0x6f, 0x06, 0xcf, 0xc3, 0x37, 0x7e, 0xe5, 0x6d, 0x5a, 0xd4, 0xbf, 0xd4,
+	0xe5, 0xa8, 0x9b, 0x1e, 0x9c, 0x0d, 0x1d, 0xc3, 0x2b, 0x8d, 0x42, 0x59, 0xdc, 0xd7, 0x78, 0x5c,
+	0x6a, 0xdc, 0xd6, 0x1a, 0x51, 0x49, 0xd8, 0x89, 0xf4, 0xf4, 0x21, 0x60, 0xbc, 0x0f, 0xe0, 0x9e,
+	0x89, 0x9e, 0xa5, 0x1b, 0xda, 0x07, 0xd8, 0x4e, 0x1b, 0x35, 0x2e, 0xca, 0xd0, 0x4f, 0xa3, 0x3d,
+	0xc4, 0xfb, 0x0c, 0xfd, 0xa6, 0xfb, 0xbb, 0x7c, 0xf8, 0xe8, 0xbc, 0x4f, 0x7b, 0x1b, 0x38, 0x16,
+	0x2a, 0x8c, 0xbc, 0x85, 0x4e, 0x2e, 0x67, 0x27, 0x5e, 0x5e, 0xe4, 0x15, 0xb7, 0xc0, 0xc2, 0xbf,
+	0x04, 0x5e, 0xb7, 0x86, 0xa1, 0xbf, 0x08, 0xdc, 0x55, 0x8e, 0xda, 0x09, 0x43, 0xbf, 0xe5, 0xe2,
+	0x5d, 0xba, 0x13, 0xae, 0x7f, 0x45, 0x47, 0x91, 0x60, 0x04, 0xdd, 0xaa, 0x75, 0xca, 0xd7, 0x28,
+	0xd1, 0x18, 0xda, 0xa9, 0xd7, 0x34, 0x11, 0x99, 0xdd, 0xb8, 0x87, 0xc7, 0x01, 0x19, 0x92, 0xf0,
+	0x0f, 0x81, 0xdb, 0x33, 0x73, 0xa1, 0xbf, 0x09, 0xf4, 0x8f, 0x33, 0x1d, 0x51, 0xc2, 0x8b, 0x1e,
+	0x5b, 0x17, 0xe6, 0x0e, 0xaf, 0xea, 0xc9, 0xd2, 0xcd, 0xfc, 0x49, 0xf9, 0x8a, 0x46, 0xff, 0x03,
+	0x00, 0x00, 0xff, 0xff, 0x78, 0x78, 0x6b, 0x30, 0xbc, 0x03, 0x00, 0x00,
 }

--- a/pkg/nsm/apis/dataplaneregistrar/dataplaneregistrar.proto
+++ b/pkg/nsm/apis/dataplaneregistrar/dataplaneregistrar.proto
@@ -25,3 +25,17 @@ service DataplaneRegistration {
     // that NSM is gone and the dataplane needs to start re-registration logic.
     rpc RequestLiveness (stream common.Empty) returns (stream common.Empty);
 }
+
+// DataplaneUnRegistrationRequest is sent by the dataplane to NSM
+// to remove itself from the list of available dataplanes.
+message DataplaneUnRegistrationRequest {
+    string dataplane_name = 1;
+  }
+  
+  message DataplaneUnRegistrationReply {
+    bool un_registered = 1;
+  }
+  
+  service DataplaneUnRegistration {
+      rpc RequestDataplaneUnRegistration (DataplaneUnRegistrationRequest) returns (DataplaneUnRegistrationReply);
+  }

--- a/pkg/nsm/apis/netmesh/netmesh.pb.go
+++ b/pkg/nsm/apis/netmesh/netmesh.pb.go
@@ -21,11 +21,11 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 // +k8s:openapi-gen=true
 type NetworkServiceEndpoint struct {
-	NetworkServiceName   string                   `protobuf:"bytes,1,opt,name=network_service_name,json=networkServiceName" json:"network_service_name,omitempty"`
-	NetworkServiceHost   string                   `protobuf:"bytes,2,opt,name=network_service_host,json=networkServiceHost" json:"network_service_host,omitempty"`
-	NseProviderName      string                   `protobuf:"bytes,3,opt,name=nse_provider_name,json=nseProviderName" json:"nse_provider_name,omitempty"`
-	SocketLocation       string                   `protobuf:"bytes,4,opt,name=socket_location,json=socketLocation" json:"socket_location,omitempty"`
-	LocalMechanisms      []*common.LocalMechanism `protobuf:"bytes,5,rep,name=local_mechanisms,json=localMechanisms" json:"local_mechanisms,omitempty"`
+	NetworkServiceName   string                   `protobuf:"bytes,1,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
+	NetworkServiceHost   string                   `protobuf:"bytes,2,opt,name=network_service_host,json=networkServiceHost,proto3" json:"network_service_host,omitempty"`
+	NseProviderName      string                   `protobuf:"bytes,3,opt,name=nse_provider_name,json=nseProviderName,proto3" json:"nse_provider_name,omitempty"`
+	SocketLocation       string                   `protobuf:"bytes,4,opt,name=socket_location,json=socketLocation,proto3" json:"socket_location,omitempty"`
+	LocalMechanisms      []*common.LocalMechanism `protobuf:"bytes,5,rep,name=local_mechanisms,json=localMechanisms,proto3" json:"local_mechanisms,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                 `json:"-"`
 	XXX_unrecognized     []byte                   `json:"-"`
 	XXX_sizecache        int32                    `json:"-"`
@@ -92,7 +92,7 @@ func (m *NetworkServiceEndpoint) GetLocalMechanisms() []*common.LocalMechanism {
 
 // +k8s:openapi-gen=true
 type NetworkService struct {
-	NetworkServiceName   string   `protobuf:"bytes,1,opt,name=network_service_name,json=networkServiceName" json:"network_service_name,omitempty"`
+	NetworkServiceName   string   `protobuf:"bytes,1,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/pkg/nsm/apis/nseconnect/nseconnect.pb.go
+++ b/pkg/nsm/apis/nseconnect/nseconnect.pb.go
@@ -26,8 +26,8 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 // EndpointConnectionRequest is sent by a NSM to NSE to build a connection.
 type EndpointConnectionRequest struct {
-	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	NetworkServiceName   string   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName" json:"network_service_name,omitempty"`
+	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NetworkServiceName   string   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -74,9 +74,9 @@ func (m *EndpointConnectionRequest) GetNetworkServiceName() string {
 // EndpointConnectionReply is sent back by NSE to NSM with information required for
 // dataplane programming.
 type EndpointConnectionReply struct {
-	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	NetworkServiceName   string   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName" json:"network_service_name,omitempty"`
-	LinuxNamespace       string   `protobuf:"bytes,3,opt,name=linux_namespace,json=linuxNamespace" json:"linux_namespace,omitempty"`
+	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NetworkServiceName   string   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
+	LinuxNamespace       string   `protobuf:"bytes,3,opt,name=linux_namespace,json=linuxNamespace,proto3" json:"linux_namespace,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -128,8 +128,8 @@ func (m *EndpointConnectionReply) GetLinuxNamespace() string {
 }
 
 type EndpointAdvertiseRequest struct {
-	RequestId            string                          `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	NetworkEndpoint      *netmesh.NetworkServiceEndpoint `protobuf:"bytes,2,opt,name=network_endpoint,json=networkEndpoint" json:"network_endpoint,omitempty"`
+	RequestId            string                          `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NetworkEndpoint      *netmesh.NetworkServiceEndpoint `protobuf:"bytes,2,opt,name=network_endpoint,json=networkEndpoint,proto3" json:"network_endpoint,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                        `json:"-"`
 	XXX_unrecognized     []byte                          `json:"-"`
 	XXX_sizecache        int32                           `json:"-"`
@@ -174,9 +174,9 @@ func (m *EndpointAdvertiseRequest) GetNetworkEndpoint() *netmesh.NetworkServiceE
 }
 
 type EndpointAdvertiseReply struct {
-	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	Accepted             bool     `protobuf:"varint,2,opt,name=accepted" json:"accepted,omitempty"`
-	AdmissionError       string   `protobuf:"bytes,3,opt,name=admission_error,json=admissionError" json:"admission_error,omitempty"`
+	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	Accepted             bool     `protobuf:"varint,2,opt,name=accepted,proto3" json:"accepted,omitempty"`
+	AdmissionError       string   `protobuf:"bytes,3,opt,name=admission_error,json=admissionError,proto3" json:"admission_error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -231,8 +231,8 @@ func (m *EndpointAdvertiseReply) GetAdmissionError() string {
 // endpoint. NSM will attempt to locate Customer Resource and delete it.
 //
 type EndpointRemoveRequest struct {
-	RequestId            string                          `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	NetworkEndpoint      *netmesh.NetworkServiceEndpoint `protobuf:"bytes,2,opt,name=network_endpoint,json=networkEndpoint" json:"network_endpoint,omitempty"`
+	RequestId            string                          `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NetworkEndpoint      *netmesh.NetworkServiceEndpoint `protobuf:"bytes,2,opt,name=network_endpoint,json=networkEndpoint,proto3" json:"network_endpoint,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                        `json:"-"`
 	XXX_unrecognized     []byte                          `json:"-"`
 	XXX_sizecache        int32                           `json:"-"`
@@ -277,9 +277,9 @@ func (m *EndpointRemoveRequest) GetNetworkEndpoint() *netmesh.NetworkServiceEndp
 }
 
 type EndpointRemoveReply struct {
-	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	Accepted             bool     `protobuf:"varint,2,opt,name=accepted" json:"accepted,omitempty"`
-	AdmissionError       string   `protobuf:"bytes,3,opt,name=admission_error,json=admissionError" json:"admission_error,omitempty"`
+	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	Accepted             bool     `protobuf:"varint,2,opt,name=accepted,proto3" json:"accepted,omitempty"`
+	AdmissionError       string   `protobuf:"bytes,3,opt,name=admission_error,json=admissionError,proto3" json:"admission_error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -371,8 +371,7 @@ func (c *endpointConnectionClient) RequestEndpointConnection(ctx context.Context
 	return out, nil
 }
 
-// Server API for EndpointConnection service
-
+// EndpointConnectionServer is the server API for EndpointConnection service.
 type EndpointConnectionServer interface {
 	RequestEndpointConnection(context.Context, *EndpointConnectionRequest) (*EndpointConnectionReply, error)
 }
@@ -446,8 +445,7 @@ func (c *endpointOperationsClient) RemoveEndpoint(ctx context.Context, in *Endpo
 	return out, nil
 }
 
-// Server API for EndpointOperations service
-
+// EndpointOperationsServer is the server API for EndpointOperations service.
 type EndpointOperationsServer interface {
 	AdvertiseEndpoint(context.Context, *EndpointAdvertiseRequest) (*EndpointAdvertiseReply, error)
 	RemoveEndpoint(context.Context, *EndpointRemoveRequest) (*EndpointRemoveReply, error)

--- a/pkg/nsm/apis/nsmconnect/nsmconnect.pb.go
+++ b/pkg/nsm/apis/nsmconnect/nsmconnect.pb.go
@@ -29,10 +29,10 @@ type ConnectionRequest struct {
 	// Since connection request will trigger certain actions
 	// executed by NSM for a client to address idempotency, request_id
 	// will be tracked.
-	RequestId            string                   `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	NetworkServiceName   string                   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName" json:"network_service_name,omitempty"`
-	LinuxNamespace       string                   `protobuf:"bytes,3,opt,name=linux_namespace,json=linuxNamespace" json:"linux_namespace,omitempty"`
-	LocalMechanisms      []*common.LocalMechanism `protobuf:"bytes,4,rep,name=local_mechanisms,json=localMechanisms" json:"local_mechanisms,omitempty"`
+	RequestId            string                   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NetworkServiceName   string                   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
+	LinuxNamespace       string                   `protobuf:"bytes,3,opt,name=linux_namespace,json=linuxNamespace,proto3" json:"linux_namespace,omitempty"`
+	LocalMechanisms      []*common.LocalMechanism `protobuf:"bytes,4,rep,name=local_mechanisms,json=localMechanisms,proto3" json:"local_mechanisms,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                 `json:"-"`
 	XXX_unrecognized     []byte                   `json:"-"`
 	XXX_sizecache        int32                    `json:"-"`
@@ -91,7 +91,7 @@ func (m *ConnectionRequest) GetLocalMechanisms() []*common.LocalMechanism {
 }
 
 type ConnectionParameters struct {
-	ConnectionParameters map[string]string `protobuf:"bytes,1,rep,name=connection_parameters,json=connectionParameters" json:"connection_parameters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ConnectionParameters map[string]string `protobuf:"bytes,1,rep,name=connection_parameters,json=connectionParameters,proto3" json:"connection_parameters,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -133,10 +133,10 @@ func (m *ConnectionParameters) GetConnectionParameters() map[string]string {
 // indicates that connection was refused and admission_error will provide details
 // why connection was refused.
 type ConnectionReply struct {
-	Accepted             bool                   `protobuf:"varint,1,opt,name=accepted" json:"accepted,omitempty"`
-	AdmissionError       string                 `protobuf:"bytes,2,opt,name=admission_error,json=admissionError" json:"admission_error,omitempty"`
-	ConnectionParameters *ConnectionParameters  `protobuf:"bytes,3,opt,name=connection_parameters,json=connectionParameters" json:"connection_parameters,omitempty"`
-	LocalMechanism       *common.LocalMechanism `protobuf:"bytes,4,opt,name=local_mechanism,json=localMechanism" json:"local_mechanism,omitempty"`
+	Accepted             bool                   `protobuf:"varint,1,opt,name=accepted,proto3" json:"accepted,omitempty"`
+	AdmissionError       string                 `protobuf:"bytes,2,opt,name=admission_error,json=admissionError,proto3" json:"admission_error,omitempty"`
+	ConnectionParameters *ConnectionParameters  `protobuf:"bytes,3,opt,name=connection_parameters,json=connectionParameters,proto3" json:"connection_parameters,omitempty"`
+	LocalMechanism       *common.LocalMechanism `protobuf:"bytes,4,opt,name=local_mechanism,json=localMechanism,proto3" json:"local_mechanism,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}               `json:"-"`
 	XXX_unrecognized     []byte                 `json:"-"`
 	XXX_sizecache        int32                  `json:"-"`
@@ -233,8 +233,7 @@ func (c *clientConnectionClient) RequestConnection(ctx context.Context, in *Conn
 	return out, nil
 }
 
-// Server API for ClientConnection service
-
+// ClientConnectionServer is the server API for ClientConnection service.
 type ClientConnectionServer interface {
 	RequestConnection(context.Context, *ConnectionRequest) (*ConnectionReply, error)
 }

--- a/pkg/nsm/apis/pod2nsm/api.pb.go
+++ b/pkg/nsm/apis/pod2nsm/api.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type DiscoverServiceRequest struct {
-	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -62,7 +62,7 @@ func (m *DiscoverServiceRequest) GetLabels() map[string]string {
 }
 
 type ServiceDiscoveryResponse struct {
-	ServiceIds           []string `protobuf:"bytes,1,rep,name=service_ids,json=serviceIds" json:"service_ids,omitempty"`
+	ServiceIds           []string `protobuf:"bytes,1,rep,name=service_ids,json=serviceIds,proto3" json:"service_ids,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -100,7 +100,7 @@ func (m *ServiceDiscoveryResponse) GetServiceIds() []string {
 }
 
 type PublishServiceRequest struct {
-	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -138,7 +138,7 @@ func (m *PublishServiceRequest) GetLabels() map[string]string {
 }
 
 type PublishServiceResponse struct {
-	ServiceId            string   `protobuf:"bytes,1,opt,name=service_id,json=serviceId" json:"service_id,omitempty"`
+	ServiceId            string   `protobuf:"bytes,1,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -176,7 +176,7 @@ func (m *PublishServiceResponse) GetServiceId() string {
 }
 
 type DelistServiceRequest struct {
-	ServiceId            string   `protobuf:"bytes,1,opt,name=service_id,json=serviceId" json:"service_id,omitempty"`
+	ServiceId            string   `protobuf:"bytes,1,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -244,7 +244,7 @@ func (m *DelistServiceResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_DelistServiceResponse proto.InternalMessageInfo
 
 type ExposeChannelRequest struct {
-	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -282,7 +282,7 @@ func (m *ExposeChannelRequest) GetLabels() map[string]string {
 }
 
 type ExposeChannelResponse struct {
-	ChannelId            string   `protobuf:"bytes,1,opt,name=channel_id,json=channelId" json:"channel_id,omitempty"`
+	ChannelId            string   `protobuf:"bytes,1,opt,name=channel_id,json=channelId,proto3" json:"channel_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -320,7 +320,7 @@ func (m *ExposeChannelResponse) GetChannelId() string {
 }
 
 type ConcealChannelRequest struct {
-	ChannelId            string   `protobuf:"bytes,1,opt,name=channel_id,json=channelId" json:"channel_id,omitempty"`
+	ChannelId            string   `protobuf:"bytes,1,opt,name=channel_id,json=channelId,proto3" json:"channel_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -388,7 +388,7 @@ func (m *ConcealChannelResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_ConcealChannelResponse proto.InternalMessageInfo
 
 type CreateConnectionRequest struct {
-	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -426,7 +426,7 @@ func (m *CreateConnectionRequest) GetLabels() map[string]string {
 }
 
 type CreateConnectionResponse struct {
-	ConnectionId         string   `protobuf:"bytes,1,opt,name=connection_id,json=connectionId" json:"connection_id,omitempty"`
+	ConnectionId         string   `protobuf:"bytes,1,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -464,7 +464,7 @@ func (m *CreateConnectionResponse) GetConnectionId() string {
 }
 
 type DestroyConnectionRequest struct {
-	ConnectionId         string   `protobuf:"bytes,1,opt,name=connection_id,json=connectionId" json:"connection_id,omitempty"`
+	ConnectionId         string   `protobuf:"bytes,1,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -644,8 +644,7 @@ func (c *networkServicesClient) DestroyConnection(ctx context.Context, in *Destr
 	return out, nil
 }
 
-// Server API for NetworkServices service
-
+// NetworkServicesServer is the server API for NetworkServices service.
 type NetworkServicesServer interface {
 	DiscoverService(context.Context, *DiscoverServiceRequest) (*ServiceDiscoveryResponse, error)
 	PublishService(context.Context, *PublishServiceRequest) (*PublishServiceResponse, error)

--- a/pkg/nsm/apis/testdataplane/testdataplane.pb.go
+++ b/pkg/nsm/apis/testdataplane/testdataplane.pb.go
@@ -50,8 +50,8 @@ func (NSMPodType) EnumDescriptor() ([]byte, []int) {
 }
 
 type Metadata struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	Namespace            string   `protobuf:"bytes,2,opt,name=namespace" json:"namespace,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace            string   `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -96,8 +96,8 @@ func (m *Metadata) GetNamespace() string {
 }
 
 type Pod struct {
-	Metadata             *Metadata `protobuf:"bytes,1,opt,name=metadata" json:"metadata,omitempty"`
-	IpAddress            string    `protobuf:"bytes,2,opt,name=ip_address,json=ipAddress" json:"ip_address,omitempty"`
+	Metadata             *Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	IpAddress            string    `protobuf:"bytes,2,opt,name=ip_address,json=ipAddress,proto3" json:"ip_address,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -142,8 +142,8 @@ func (m *Pod) GetIpAddress() string {
 }
 
 type BuildConnectRequest struct {
-	SourcePod            *Pod     `protobuf:"bytes,1,opt,name=source_pod,json=sourcePod" json:"source_pod,omitempty"`
-	DestinationPod       *Pod     `protobuf:"bytes,2,opt,name=destination_pod,json=destinationPod" json:"destination_pod,omitempty"`
+	SourcePod            *Pod     `protobuf:"bytes,1,opt,name=source_pod,json=sourcePod,proto3" json:"source_pod,omitempty"`
+	DestinationPod       *Pod     `protobuf:"bytes,2,opt,name=destination_pod,json=destinationPod,proto3" json:"destination_pod,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -188,8 +188,8 @@ func (m *BuildConnectRequest) GetDestinationPod() *Pod {
 }
 
 type BuildConnectReply struct {
-	Built                bool     `protobuf:"varint,1,opt,name=built" json:"built,omitempty"`
-	BuildError           string   `protobuf:"bytes,2,opt,name=build_error,json=buildError" json:"build_error,omitempty"`
+	Built                bool     `protobuf:"varint,1,opt,name=built,proto3" json:"built,omitempty"`
+	BuildError           string   `protobuf:"bytes,2,opt,name=build_error,json=buildError,proto3" json:"build_error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -234,8 +234,8 @@ func (m *BuildConnectReply) GetBuildError() string {
 }
 
 type DeleteConnectRequest struct {
-	Pod                  *Pod       `protobuf:"bytes,1,opt,name=pod" json:"pod,omitempty"`
-	PodType              NSMPodType `protobuf:"varint,2,opt,name=pod_type,json=podType,enum=testdataplane.NSMPodType" json:"pod_type,omitempty"`
+	Pod                  *Pod       `protobuf:"bytes,1,opt,name=pod,proto3" json:"pod,omitempty"`
+	PodType              NSMPodType `protobuf:"varint,2,opt,name=pod_type,json=podType,proto3,enum=testdataplane.NSMPodType" json:"pod_type,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
 	XXX_unrecognized     []byte     `json:"-"`
 	XXX_sizecache        int32      `json:"-"`
@@ -280,8 +280,8 @@ func (m *DeleteConnectRequest) GetPodType() NSMPodType {
 }
 
 type DeleteConnectReply struct {
-	Deleted              bool     `protobuf:"varint,1,opt,name=deleted" json:"deleted,omitempty"`
-	DeleteError          string   `protobuf:"bytes,2,opt,name=delete_error,json=deleteError" json:"delete_error,omitempty"`
+	Deleted              bool     `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	DeleteError          string   `protobuf:"bytes,2,opt,name=delete_error,json=deleteError,proto3" json:"delete_error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -367,8 +367,7 @@ func (c *buildConnectClient) RequestBuildConnect(ctx context.Context, in *BuildC
 	return out, nil
 }
 
-// Server API for BuildConnect service
-
+// BuildConnectServer is the server API for BuildConnect service.
 type BuildConnectServer interface {
 	RequestBuildConnect(context.Context, *BuildConnectRequest) (*BuildConnectReply, error)
 }
@@ -432,8 +431,7 @@ func (c *deleteConnectClient) RequestDeleteConnect(ctx context.Context, in *Dele
 	return out, nil
 }
 
-// Server API for DeleteConnect service
-
+// DeleteConnectServer is the server API for DeleteConnect service.
 type DeleteConnectServer interface {
 	RequestDeleteConnect(context.Context, *DeleteConnectRequest) (*DeleteConnectReply, error)
 }

--- a/plugins/dataplaneregistrar/dataplaneregistrar_reg.go
+++ b/plugins/dataplaneregistrar/dataplaneregistrar_reg.go
@@ -128,6 +128,15 @@ func (r *dataplaneRegistrarServer) RequestDataplaneRegistration(ctx context.Cont
 	return &dataplaneregistrarapi.DataplaneRegistrationReply{Registered: true}, nil
 }
 
+func (r *dataplaneRegistrarServer) RequestDataplaneUnRegistration(ctx context.Context, req *dataplaneregistrarapi.DataplaneUnRegistrationRequest) (*dataplaneregistrarapi.DataplaneUnRegistrationReply, error) {
+	r.logger.Infof("Received dataplane un-registration requests from %s", req.DataplaneName)
+
+	// Removing dataplane from the store, if it does not exists, it does not matter as long as it is no longer there.
+	r.objectStore.RemoveDataplane(req.DataplaneName)
+
+	return &dataplaneregistrarapi.DataplaneUnRegistrationReply{UnRegistered: true}, nil
+}
+
 // startDataplaneServer starts for a server listening for local NSEs advertise/remove
 // dataplane registrar calls
 func startDataplaneRegistrarServer(dataplaneRegistrarServer *dataplaneRegistrarServer) error {
@@ -146,6 +155,8 @@ func startDataplaneRegistrarServer(dataplaneRegistrarServer *dataplaneRegistrarS
 
 	// Plugging dataplane registrar operations methods
 	dataplaneregistrarapi.RegisterDataplaneRegistrationServer(dataplaneRegistrarServer.grpcServer, dataplaneRegistrarServer)
+	// Plugging dataplane registrar operations methods
+	dataplaneregistrarapi.RegisterDataplaneUnRegistrationServer(dataplaneRegistrarServer.grpcServer, dataplaneRegistrarServer)
 
 	logger.Infof("Starting Dataplane Registrar gRPC server listening on socket: %s", dataplaneRegistrar)
 	go func() {

--- a/plugins/objectstore/objectstore_api.go
+++ b/plugins/objectstore/objectstore_api.go
@@ -35,6 +35,7 @@ type Interface interface {
 	GetNetworkService(nsName string) *v1.NetworkService
 	ListNetworkServices() []*v1.NetworkService
 	GetDataplane(registeredName string) *Dataplane
+	RemoveDataplane(registeredName string)
 	ListDataplanes() []*Dataplane
 }
 

--- a/plugins/objectstore/objectstore_plugin.go
+++ b/plugins/objectstore/objectstore_plugin.go
@@ -104,6 +104,13 @@ func (p *Plugin) GetDataplane(registeredName string) *Dataplane {
 	return p.objects.dataplaneStore.Get(registeredName)
 }
 
+// RemoveDataplane get Dataplane object by registration name
+func (p *Plugin) RemoveDataplane(registeredName string) {
+	p.Log.Info("ObjectStore.RemoveDataplane.")
+	p.objects.dataplaneStore.Delete(registeredName)
+	return
+}
+
 // ListDataplanes lists all stored Dataplane objects
 func (p *Plugin) ListDataplanes() []*Dataplane {
 	p.Log.Info("ObjectStore.ListDataplane.")


### PR DESCRIPTION
When an external dataplane controller finds itself unable to serve NSM requests, it will call UnRegister call so NSM will not waste time on it. Once this dataplane controller come back to its senses it will register with NSM again. 
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>