### PR TITLE
Update the CI to use the latest minikube and kubernetes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - go install ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
   - make dep-check
   - yamllint -c .yamllint.yml $(git ls-files '*.yaml' '*.yml' | grep -v 'vendor/')
-  - make all && ./scripts/travis-integration-tests.sh minikube
+  - make all && ./scripts/travis-integration-tests.sh dind
 
 # We only want to push docker images on a push to master, not a pull request
 after_success:

--- a/scripts/cluster-up-dind.sh
+++ b/scripts/cluster-up-dind.sh
@@ -19,6 +19,9 @@
 DIND_CLUSTER_SH=dind-cluster-v1.11.sh
 DIND_URL=https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/${DIND_CLUSTER_SH}
 
+# The number of nodes to test with. For now, lets use a single node cluster
+export NUM_NODES=1
+
 rm -f ${DIND_CLUSTER_SH}
 wget ${DIND_URL}
 chmod +x ${DIND_CLUSTER_SH}

--- a/scripts/cluster-up-dind.sh
+++ b/scripts/cluster-up-dind.sh
@@ -22,6 +22,9 @@ DIND_URL=https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/${DIN
 # The number of nodes to test with. For now, lets use a single node cluster
 export NUM_NODES=1
 
+# Enable RBAC on the API server
+export APISERVER_authorization_mode=RBAC
+
 rm -f ${DIND_CLUSTER_SH}
 wget ${DIND_URL}
 chmod +x ${DIND_CLUSTER_SH}

--- a/scripts/cluster-up-dind.sh
+++ b/scripts/cluster-up-dind.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Bring up kubeadm-dind-cluster (docker-in-docker k8s cluster)
-DIND_CLUSTER_SH=dind-cluster-v1.7.sh
+DIND_CLUSTER_SH=dind-cluster-v1.11.sh
 DIND_URL=https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/${DIND_CLUSTER_SH}
 
 rm -f ${DIND_CLUSTER_SH}

--- a/scripts/cluster-up-dind.sh
+++ b/scripts/cluster-up-dind.sh
@@ -23,4 +23,7 @@ rm -f ${DIND_CLUSTER_SH}
 wget ${DIND_URL}
 chmod +x ${DIND_CLUSTER_SH}
 ./${DIND_CLUSTER_SH} up
+export PATH="${HOME}/.kubeadm-dind-cluster:${PATH}"
+# Wait for Kubernetes to be up and ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 # vim: sw=4 ts=4 et si

--- a/scripts/cluster-up-minikube.sh
+++ b/scripts/cluster-up-minikube.sh
@@ -28,8 +28,8 @@ touch ~/.kube/config
 export KUBECONFIG=$HOME/.kube/config
 export PATH=${PATH}:${GOPATH:?}/bin
 
-MINIKUBE_VERSION=v0.28.1
-KUBERNETES_VERSION=v1.10.0
+MINIKUBE_VERSION=v0.29.0
+KUBERNETES_VERSION=v1.12.0
 
 install_bin() {
     local exe=${1:?}
@@ -82,7 +82,7 @@ MINIKUBE_BIN=$(command -v minikube)
 sudo -E "${MINIKUBE_BIN}" start --vm-driver=none \
     --extra-config=apiserver.Authorization.Mode=RBAC \
     --kubernetes-version="${KUBERNETES_VERSION}" \
-    --bootstrapper=localkube
+    --bootstrapper=kubeadm
 
 # Wait til settles
 echo "INFO: Waiting for minikube cluster to be ready ..."

--- a/scripts/integration-test-helpers.sh
+++ b/scripts/integration-test-helpers.sh
@@ -92,6 +92,7 @@ function wait_for_pods() {
 # In case if a failure, collecting some evidence for further debugging
 #
 function error_collection() {
+    set -xe
     kubectl describe node || true
     kubectl get pods --all-namespaces || true
     nsm=$(kubectl get pods --all-namespaces | grep networkservice | awk '{print $2}')
@@ -129,6 +130,7 @@ function error_collection() {
     fi
     kubectl get nodes
     sudo docker images
+    set +xe
 }
 
 # vim: sw=4 ts=4 et si

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -21,7 +21,8 @@ function run_tests() {
     kubectl get nodes
     kubectl version
     kubectl api-versions
-    kubectl label --overwrite --all=true nodes app=networkservice-node
+    #kubectl label --overwrite --all=true nodes app=networkservice-node
+    kubectl label --overwrite nodes kube-node-1 app=networkservice-node
     kubectl create -f conf/sample/networkservice-daemonset.yaml
     #
     # Now let's wait for all pods to get into running state

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -141,9 +141,13 @@ function run_tests() {
     kubectl get nodes
     kubectl get pods
     kubectl get crd
-    kubectl logs "$(kubectl get pods -o name | grep nse )"
-    kubectl logs "$(kubectl get pods -o name | grep nsm-client )" -c nsm-init
-    kubectl logs "$(kubectl get pods -o name | grep test-dataplane )"
+    kubectl logs "$(kubectl get pods -o name | grep nse)"
+    kubectl logs "$(kubectl get pods -o name | grep nsm-client)" -c nsm-init
+    kubectl logs "$(kubectl get pods -o name | grep test-dataplane | cut -d "/" -f 2)"
+    DATAPLANES="$(kubectl get pods -o name | grep test-dataplane | cut -d "/" -f 2)"
+    for TESTDP in ${DATAPLANES} ; do
+        kubectl logs "${TESTDP}"
+    done
     kubectl get NetworkService,NetworkServiceEndpoint --all-namespaces
 
     # Need to get kubeconfig full path

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -21,8 +21,8 @@ function run_tests() {
     kubectl get nodes
     kubectl version
     kubectl api-versions
-    #kubectl label --overwrite --all=true nodes app=networkservice-node
-    kubectl label --overwrite nodes kube-node-1 app=networkservice-node
+    kubectl label --overwrite --all=true nodes app=networkservice-node
+    #kubectl label --overwrite nodes kube-node-1 app=networkservice-node
     kubectl create -f conf/sample/networkservice-daemonset.yaml
     #
     # Now let's wait for all pods to get into running state
@@ -143,7 +143,6 @@ function run_tests() {
     kubectl get crd
     kubectl logs "$(kubectl get pods -o name | grep nse)"
     kubectl logs "$(kubectl get pods -o name | grep nsm-client)" -c nsm-init
-    kubectl logs "$(kubectl get pods -o name | grep test-dataplane | cut -d "/" -f 2)"
     DATAPLANES="$(kubectl get pods -o name | grep test-dataplane | cut -d "/" -f 2)"
     for TESTDP in ${DATAPLANES} ; do
         kubectl logs "${TESTDP}"

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -48,7 +48,6 @@ function run_tests() {
     # Since daemonset is up and running, create CRD resources
     #
     kubectl create -f conf/sample/networkservice.yaml
-    kubectl logs "$(kubectl get pods -o name | sed -e 's/.*\///')"
     wait_for_networkservice default
 
     #

--- a/scripts/travis-integration-tests.sh
+++ b/scripts/travis-integration-tests.sh
@@ -23,7 +23,7 @@ test -n "${TRAVIS_K8S_CONTEXT}" && set -- "${TRAVIS_K8S_CONTEXT}"
 
 export TEST_CONTEXT=${1:?}
 
-KUBECTL_VERSION=v1.11.0
+KUBECTL_VERSION=v1.12.0
 
 # Install kubectl
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBECTL_VERSION}"/bin/linux/amd64/kubectl && \

--- a/scripts/travis-integration-tests.sh
+++ b/scripts/travis-integration-tests.sh
@@ -23,7 +23,7 @@ test -n "${TRAVIS_K8S_CONTEXT}" && set -- "${TRAVIS_K8S_CONTEXT}"
 
 export TEST_CONTEXT=${1:?}
 
-KUBECTL_VERSION=v1.12.0
+KUBECTL_VERSION=v1.11.3
 
 # Install kubectl
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBECTL_VERSION}"/bin/linux/amd64/kubectl && \


### PR DESCRIPTION
Closes #311

This updates the CI to use the latest minikube (v0.29.0) and kubernetes
(v1.12.0) for testing.

NOTE: I expect this to fail at the moment since the kubeadm bootstrapper seems to
have some issues here. Pushing this out to see if it fails the same way as it does
in my local environment.

Signed-off-by: Kyle Mestery <mestery@mestery.com>