### PR TITLE
Add grpc service to inform nse about interface name

### DIFF
--- a/.api_violations.report
+++ b/.api_violations.report
@@ -1,0 +1,6 @@
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkService,NetworkServiceName
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkServiceEndpoint,NetworkServiceName
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkServiceEndpoint,NetworkServiceHost
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkServiceEndpoint,NseProviderName
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkServiceEndpoint,SocketLocation
+API rule violation: names_match,github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh,NetworkServiceEndpoint,LocalMechanisms

--- a/cmd/examples/nse/nse.go
+++ b/cmd/examples/nse/nse.go
@@ -63,11 +63,11 @@ func (n nseConnection) RequestEndpointConnection(ctx context.Context, req *nseco
 	}, nil
 }
 
-func (n nseConnection) SendEndpointConnectionInterface(ctx context.Context, req *nseconnect.EndpointConnectionInterface) (*nseconnect.EndpointConnectionInterfaceReply, error) {
+func (n nseConnection) SendEndpointConnectionMechanism(ctx context.Context, req *nseconnect.EndpointConnectionMechanism) (*nseconnect.EndpointConnectionMechanismReply, error) {
 
-	return &nseconnect.EndpointConnectionInterfaceReply{
+	return &nseconnect.EndpointConnectionMechanismReply{
 		RequestId:      req.RequestId,
-		InterfaceFound: true,
+		MechanismFound: true,
 	}, nil
 }
 

--- a/cmd/examples/nse/nse.go
+++ b/cmd/examples/nse/nse.go
@@ -63,6 +63,14 @@ func (n nseConnection) RequestEndpointConnection(ctx context.Context, req *nseco
 	}, nil
 }
 
+func (n nseConnection) SendEndpointConnectionInterface(ctx context.Context, req *nseconnect.EndpointConnectionInterface) (*nseconnect.EndpointConnectionInterfaceReply, error) {
+
+	return &nseconnect.EndpointConnectionInterfaceReply{
+		RequestId:      req.RequestId,
+		InterfaceFound: true,
+	}, nil
+}
+
 func buildClient() (*kubernetes.Clientset, error) {
 	var config *rest.Config
 	var err error

--- a/pkg/apis/networkservicemesh.io/v1/openapi_generated.go
+++ b/pkg/apis/networkservicemesh.io/v1/openapi_generated.go
@@ -31,6 +31,8 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1.NetworkServiceEndpoint":     schema_pkg_apis_networkservicemeshio_v1_NetworkServiceEndpoint(ref),
 		"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1.NetworkServiceEndpointList": schema_pkg_apis_networkservicemeshio_v1_NetworkServiceEndpointList(ref),
 		"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1.NetworkServiceList":         schema_pkg_apis_networkservicemeshio_v1_NetworkServiceList(ref),
+		"github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh.NetworkService":                          schema_pkg_nsm_apis_netmesh_NetworkService(ref),
+		"github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh.NetworkServiceEndpoint":                  schema_pkg_nsm_apis_netmesh_NetworkServiceEndpoint(ref),
 	}
 }
 
@@ -211,5 +213,72 @@ func schema_pkg_apis_networkservicemeshio_v1_NetworkServiceList(ref common.Refer
 		},
 		Dependencies: []string{
 			"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1.NetworkService", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+	}
+}
+
+func schema_pkg_nsm_apis_netmesh_NetworkService(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"network_service_name": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_pkg_nsm_apis_netmesh_NetworkServiceEndpoint(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"network_service_name": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"network_service_host": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"nse_provider_name": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"socket_location": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"local_mechanisms": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/ligato/networkservicemesh/pkg/nsm/apis/common.LocalMechanism"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"github.com/ligato/networkservicemesh/pkg/nsm/apis/common.LocalMechanism"},
 	}
 }

--- a/pkg/nsm/apis/common/common.pb.go
+++ b/pkg/nsm/apis/common/common.pb.go
@@ -125,8 +125,8 @@ func (m *Empty) XXX_DiscardUnknown() {
 var xxx_messageInfo_Empty proto.InternalMessageInfo
 
 type LocalMechanism struct {
-	Type                 LocalMechanismType `protobuf:"varint,1,opt,name=type,enum=common.LocalMechanismType" json:"type,omitempty"`
-	Parameters           map[string]string  `protobuf:"bytes,2,rep,name=parameters" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Type                 LocalMechanismType `protobuf:"varint,1,opt,name=type,proto3,enum=common.LocalMechanismType" json:"type,omitempty"`
+	Parameters           map[string]string  `protobuf:"bytes,2,rep,name=parameters,proto3" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -171,8 +171,8 @@ func (m *LocalMechanism) GetParameters() map[string]string {
 }
 
 type RemoteMechanism struct {
-	Type                 RemoteMechanismType `protobuf:"varint,1,opt,name=type,enum=common.RemoteMechanismType" json:"type,omitempty"`
-	Parameters           map[string]string   `protobuf:"bytes,2,rep,name=parameters" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Type                 RemoteMechanismType `protobuf:"varint,1,opt,name=type,proto3,enum=common.RemoteMechanismType" json:"type,omitempty"`
+	Parameters           map[string]string   `protobuf:"bytes,2,rep,name=parameters,proto3" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
 	XXX_unrecognized     []byte              `json:"-"`
 	XXX_sizecache        int32               `json:"-"`

--- a/pkg/nsm/apis/dataplane/dataplane.pb.go
+++ b/pkg/nsm/apis/dataplane/dataplane.pb.go
@@ -27,8 +27,8 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 // Message sent by dataplane module informing NSM of any changes in its
 // operations parameters or constraints
 type MechanismUpdate struct {
-	RemoteMechanisms     []*common.RemoteMechanism `protobuf:"bytes,1,rep,name=remote_mechanisms,json=remoteMechanisms" json:"remote_mechanisms,omitempty"`
-	LocalMechanisms      []*common.LocalMechanism  `protobuf:"bytes,2,rep,name=local_mechanisms,json=localMechanisms" json:"local_mechanisms,omitempty"`
+	RemoteMechanisms     []*common.RemoteMechanism `protobuf:"bytes,1,rep,name=remote_mechanisms,json=remoteMechanisms,proto3" json:"remote_mechanisms,omitempty"`
+	LocalMechanisms      []*common.LocalMechanism  `protobuf:"bytes,2,rep,name=local_mechanisms,json=localMechanisms,proto3" json:"local_mechanisms,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
 	XXX_unrecognized     []byte                    `json:"-"`
 	XXX_sizecache        int32                     `json:"-"`
@@ -73,14 +73,14 @@ func (m *MechanismUpdate) GetLocalMechanisms() []*common.LocalMechanism {
 }
 
 type Connection struct {
-	LocalSource *common.LocalMechanism `protobuf:"bytes,1,opt,name=local_source,json=localSource" json:"local_source,omitempty"`
+	LocalSource *common.LocalMechanism `protobuf:"bytes,1,opt,name=local_source,json=localSource,proto3" json:"local_source,omitempty"`
 	// Types that are valid to be assigned to Destination:
 	//	*Connection_Local
 	//	*Connection_Remote
 	Destination isConnection_Destination `protobuf_oneof:"destination"`
 	// For ConnectRequest this will be nil, but for DisconnectRequest it will
 	// carry a connection id returned by the dataplane controller
-	ConnectionId         string   `protobuf:"bytes,4,opt,name=connection_id,json=connectionId" json:"connection_id,omitempty"`
+	ConnectionId         string   `protobuf:"bytes,4,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -110,30 +110,32 @@ func (m *Connection) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Connection proto.InternalMessageInfo
 
+func (m *Connection) GetLocalSource() *common.LocalMechanism {
+	if m != nil {
+		return m.LocalSource
+	}
+	return nil
+}
+
 type isConnection_Destination interface {
 	isConnection_Destination()
 }
 
 type Connection_Local struct {
-	Local *common.LocalMechanism `protobuf:"bytes,2,opt,name=local,oneof"`
-}
-type Connection_Remote struct {
-	Remote *common.RemoteMechanism `protobuf:"bytes,3,opt,name=remote,oneof"`
+	Local *common.LocalMechanism `protobuf:"bytes,2,opt,name=local,proto3,oneof"`
 }
 
-func (*Connection_Local) isConnection_Destination()  {}
+type Connection_Remote struct {
+	Remote *common.RemoteMechanism `protobuf:"bytes,3,opt,name=remote,proto3,oneof"`
+}
+
+func (*Connection_Local) isConnection_Destination() {}
+
 func (*Connection_Remote) isConnection_Destination() {}
 
 func (m *Connection) GetDestination() isConnection_Destination {
 	if m != nil {
 		return m.Destination
-	}
-	return nil
-}
-
-func (m *Connection) GetLocalSource() *common.LocalMechanism {
-	if m != nil {
-		return m.LocalSource
 	}
 	return nil
 }
@@ -234,12 +236,12 @@ func _Connection_OneofSizer(msg proto.Message) (n int) {
 }
 
 type Reply struct {
-	Success       bool   `protobuf:"varint,1,opt,name=success" json:"success,omitempty"`
-	ExtendedError string `protobuf:"bytes,2,opt,name=extended_error,json=extendedError" json:"extended_error,omitempty"`
+	Success       bool   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	ExtendedError string `protobuf:"bytes,2,opt,name=extended_error,json=extendedError,proto3" json:"extended_error,omitempty"`
 	// ConnectRequest will populate this field with connection id returned by the
 	// dataplane controller
 	// DisconnectRequest ignores this field
-	ConnectionId         string   `protobuf:"bytes,3,opt,name=connection_id,json=connectionId" json:"connection_id,omitempty"`
+	ConnectionId         string   `protobuf:"bytes,3,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -371,8 +373,7 @@ func (c *dataplaneOperationsClient) DisconnectRequest(ctx context.Context, in *C
 	return out, nil
 }
 
-// Server API for DataplaneOperations service
-
+// DataplaneOperationsServer is the server API for DataplaneOperations service.
 type DataplaneOperationsServer interface {
 	MonitorMechanisms(*common.Empty, DataplaneOperations_MonitorMechanismsServer) error
 	ConnectRequest(context.Context, *Connection) (*Reply, error)

--- a/pkg/nsm/apis/dataplaneregistrar/dataplaneregistrar.pb.go
+++ b/pkg/nsm/apis/dataplaneregistrar/dataplaneregistrar.pb.go
@@ -28,8 +28,8 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 // to advertise itself and inform NSM about the location of the dataplane socket
 // and its initially supported parameters.
 type DataplaneRegistrationRequest struct {
-	DataplaneName        string   `protobuf:"bytes,1,opt,name=dataplane_name,json=dataplaneName" json:"dataplane_name,omitempty"`
-	DataplaneSocket      string   `protobuf:"bytes,2,opt,name=dataplane_socket,json=dataplaneSocket" json:"dataplane_socket,omitempty"`
+	DataplaneName        string   `protobuf:"bytes,1,opt,name=dataplane_name,json=dataplaneName,proto3" json:"dataplane_name,omitempty"`
+	DataplaneSocket      string   `protobuf:"bytes,2,opt,name=dataplane_socket,json=dataplaneSocket,proto3" json:"dataplane_socket,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -74,7 +74,7 @@ func (m *DataplaneRegistrationRequest) GetDataplaneSocket() string {
 }
 
 type DataplaneRegistrationReply struct {
-	Registered           bool     `protobuf:"varint,1,opt,name=registered" json:"registered,omitempty"`
+	Registered           bool     `protobuf:"varint,1,opt,name=registered,proto3" json:"registered,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -114,7 +114,7 @@ func (m *DataplaneRegistrationReply) GetRegistered() bool {
 // DataplaneUnRegistrationRequest is sent by the dataplane to NSM
 // to remove itself from the list of available dataplanes.
 type DataplaneUnRegistrationRequest struct {
-	DataplaneName        string   `protobuf:"bytes,1,opt,name=dataplane_name,json=dataplaneName" json:"dataplane_name,omitempty"`
+	DataplaneName        string   `protobuf:"bytes,1,opt,name=dataplane_name,json=dataplaneName,proto3" json:"dataplane_name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -152,7 +152,7 @@ func (m *DataplaneUnRegistrationRequest) GetDataplaneName() string {
 }
 
 type DataplaneUnRegistrationReply struct {
-	UnRegistered         bool     `protobuf:"varint,1,opt,name=un_registered,json=unRegistered" json:"un_registered,omitempty"`
+	UnRegistered         bool     `protobuf:"varint,1,opt,name=un_registered,json=unRegistered,proto3" json:"un_registered,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -263,8 +263,7 @@ func (x *dataplaneRegistrationRequestLivenessClient) Recv() (*common.Empty, erro
 	return m, nil
 }
 
-// Server API for DataplaneRegistration service
-
+// DataplaneRegistrationServer is the server API for DataplaneRegistration service.
 type DataplaneRegistrationServer interface {
 	RequestDataplaneRegistration(context.Context, *DataplaneRegistrationRequest) (*DataplaneRegistrationReply, error)
 	// RequestLiveness is a stream initiated by NSM to inform the dataplane that NSM is still alive and
@@ -365,8 +364,7 @@ func (c *dataplaneUnRegistrationClient) RequestDataplaneUnRegistration(ctx conte
 	return out, nil
 }
 
-// Server API for DataplaneUnRegistration service
-
+// DataplaneUnRegistrationServer is the server API for DataplaneUnRegistration service.
 type DataplaneUnRegistrationServer interface {
 	RequestDataplaneUnRegistration(context.Context, *DataplaneUnRegistrationRequest) (*DataplaneUnRegistrationReply, error)
 }

--- a/pkg/nsm/apis/netmesh/netmesh.pb.go
+++ b/pkg/nsm/apis/netmesh/netmesh.pb.go
@@ -19,6 +19,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
+// +k8s:openapi-gen=true
 type NetworkServiceEndpoint struct {
 	NetworkServiceName   string                   `protobuf:"bytes,1,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
 	NetworkServiceHost   string                   `protobuf:"bytes,2,opt,name=network_service_host,json=networkServiceHost,proto3" json:"network_service_host,omitempty"`
@@ -89,6 +90,7 @@ func (m *NetworkServiceEndpoint) GetLocalMechanisms() []*common.LocalMechanism {
 	return nil
 }
 
+// +k8s:openapi-gen=true
 type NetworkService struct {
 	NetworkServiceName   string   `protobuf:"bytes,1,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/pkg/nsm/apis/netmesh/netmesh.pb.go
+++ b/pkg/nsm/apis/netmesh/netmesh.pb.go
@@ -19,13 +19,12 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-// +k8s:openapi-gen=true
 type NetworkServiceEndpoint struct {
-	NetworkServiceName   string                   `protobuf:"bytes,1,opt,name=network_service_name,json=networkServiceName" json:"network_service_name,omitempty"`
-	NetworkServiceHost   string                   `protobuf:"bytes,2,opt,name=network_service_host,json=networkServiceHost" json:"network_service_host,omitempty"`
-	NseProviderName      string                   `protobuf:"bytes,3,opt,name=nse_provider_name,json=nseProviderName" json:"nse_provider_name,omitempty"`
-	SocketLocation       string                   `protobuf:"bytes,4,opt,name=socket_location,json=socketLocation" json:"socket_location,omitempty"`
-	LocalMechanisms      []*common.LocalMechanism `protobuf:"bytes,5,rep,name=local_mechanisms,json=localMechanisms" json:"local_mechanisms,omitempty"`
+	NetworkServiceName   string                   `protobuf:"bytes,1,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
+	NetworkServiceHost   string                   `protobuf:"bytes,2,opt,name=network_service_host,json=networkServiceHost,proto3" json:"network_service_host,omitempty"`
+	NseProviderName      string                   `protobuf:"bytes,3,opt,name=nse_provider_name,json=nseProviderName,proto3" json:"nse_provider_name,omitempty"`
+	SocketLocation       string                   `protobuf:"bytes,4,opt,name=socket_location,json=socketLocation,proto3" json:"socket_location,omitempty"`
+	LocalMechanisms      []*common.LocalMechanism `protobuf:"bytes,5,rep,name=local_mechanisms,json=localMechanisms,proto3" json:"local_mechanisms,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                 `json:"-"`
 	XXX_unrecognized     []byte                   `json:"-"`
 	XXX_sizecache        int32                    `json:"-"`
@@ -90,9 +89,8 @@ func (m *NetworkServiceEndpoint) GetLocalMechanisms() []*common.LocalMechanism {
 	return nil
 }
 
-// +k8s:openapi-gen=true
 type NetworkService struct {
-	NetworkServiceName   string   `protobuf:"bytes,1,opt,name=network_service_name,json=networkServiceName" json:"network_service_name,omitempty"`
+	NetworkServiceName   string   `protobuf:"bytes,1,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/pkg/nsm/apis/nseconnect/nseconnect.pb.go
+++ b/pkg/nsm/apis/nseconnect/nseconnect.pb.go
@@ -6,6 +6,7 @@ package nseconnect
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
+import common "github.com/ligato/networkservicemesh/pkg/nsm/apis/common"
 import netmesh "github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh"
 
 import (
@@ -37,7 +38,7 @@ func (m *EndpointConnectionRequest) Reset()         { *m = EndpointConnectionReq
 func (m *EndpointConnectionRequest) String() string { return proto.CompactTextString(m) }
 func (*EndpointConnectionRequest) ProtoMessage()    {}
 func (*EndpointConnectionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_f691f309118b0090, []int{0}
+	return fileDescriptor_nseconnect_54fa9345bcf3911d, []int{0}
 }
 func (m *EndpointConnectionRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointConnectionRequest.Unmarshal(m, b)
@@ -86,7 +87,7 @@ func (m *EndpointConnectionReply) Reset()         { *m = EndpointConnectionReply
 func (m *EndpointConnectionReply) String() string { return proto.CompactTextString(m) }
 func (*EndpointConnectionReply) ProtoMessage()    {}
 func (*EndpointConnectionReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_f691f309118b0090, []int{1}
+	return fileDescriptor_nseconnect_54fa9345bcf3911d, []int{1}
 }
 func (m *EndpointConnectionReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointConnectionReply.Unmarshal(m, b)
@@ -129,54 +130,54 @@ func (m *EndpointConnectionReply) GetLinuxNamespace() string {
 
 // EndpointConnectionInterface is sent by a NSM to NSE to inform NSE about
 // the interface name which was created by the dataplane controller.
-type EndpointConnectionInterface struct {
-	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
-	InterfaceName        string   `protobuf:"bytes,2,opt,name=interface_name,json=interfaceName,proto3" json:"interface_name,omitempty"`
-	NetworkServiceName   string   `protobuf:"bytes,3,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+type EndpointConnectionMechanism struct {
+	RequestId            string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	LocalMechanism       *common.LocalMechanism `protobuf:"bytes,2,opt,name=local_mechanism,json=localMechanism,proto3" json:"local_mechanism,omitempty"`
+	NetworkServiceName   string                 `protobuf:"bytes,3,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}               `json:"-"`
+	XXX_unrecognized     []byte                 `json:"-"`
+	XXX_sizecache        int32                  `json:"-"`
 }
 
-func (m *EndpointConnectionInterface) Reset()         { *m = EndpointConnectionInterface{} }
-func (m *EndpointConnectionInterface) String() string { return proto.CompactTextString(m) }
-func (*EndpointConnectionInterface) ProtoMessage()    {}
-func (*EndpointConnectionInterface) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_f691f309118b0090, []int{2}
+func (m *EndpointConnectionMechanism) Reset()         { *m = EndpointConnectionMechanism{} }
+func (m *EndpointConnectionMechanism) String() string { return proto.CompactTextString(m) }
+func (*EndpointConnectionMechanism) ProtoMessage()    {}
+func (*EndpointConnectionMechanism) Descriptor() ([]byte, []int) {
+	return fileDescriptor_nseconnect_54fa9345bcf3911d, []int{2}
 }
-func (m *EndpointConnectionInterface) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_EndpointConnectionInterface.Unmarshal(m, b)
+func (m *EndpointConnectionMechanism) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_EndpointConnectionMechanism.Unmarshal(m, b)
 }
-func (m *EndpointConnectionInterface) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_EndpointConnectionInterface.Marshal(b, m, deterministic)
+func (m *EndpointConnectionMechanism) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_EndpointConnectionMechanism.Marshal(b, m, deterministic)
 }
-func (dst *EndpointConnectionInterface) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EndpointConnectionInterface.Merge(dst, src)
+func (dst *EndpointConnectionMechanism) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EndpointConnectionMechanism.Merge(dst, src)
 }
-func (m *EndpointConnectionInterface) XXX_Size() int {
-	return xxx_messageInfo_EndpointConnectionInterface.Size(m)
+func (m *EndpointConnectionMechanism) XXX_Size() int {
+	return xxx_messageInfo_EndpointConnectionMechanism.Size(m)
 }
-func (m *EndpointConnectionInterface) XXX_DiscardUnknown() {
-	xxx_messageInfo_EndpointConnectionInterface.DiscardUnknown(m)
+func (m *EndpointConnectionMechanism) XXX_DiscardUnknown() {
+	xxx_messageInfo_EndpointConnectionMechanism.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_EndpointConnectionInterface proto.InternalMessageInfo
+var xxx_messageInfo_EndpointConnectionMechanism proto.InternalMessageInfo
 
-func (m *EndpointConnectionInterface) GetRequestId() string {
+func (m *EndpointConnectionMechanism) GetRequestId() string {
 	if m != nil {
 		return m.RequestId
 	}
 	return ""
 }
 
-func (m *EndpointConnectionInterface) GetInterfaceName() string {
+func (m *EndpointConnectionMechanism) GetLocalMechanism() *common.LocalMechanism {
 	if m != nil {
-		return m.InterfaceName
+		return m.LocalMechanism
 	}
-	return ""
+	return nil
 }
 
-func (m *EndpointConnectionInterface) GetNetworkServiceName() string {
+func (m *EndpointConnectionMechanism) GetNetworkServiceName() string {
 	if m != nil {
 		return m.NetworkServiceName
 	}
@@ -185,48 +186,48 @@ func (m *EndpointConnectionInterface) GetNetworkServiceName() string {
 
 // EndpointConnectionInterfaceReply is sent back by NSE to NSM to confirm the presence
 // of the programmed interface.
-type EndpointConnectionInterfaceReply struct {
+type EndpointConnectionMechanismReply struct {
 	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
-	InterfaceFound       bool     `protobuf:"varint,2,opt,name=interface_found,json=interfaceFound,proto3" json:"interface_found,omitempty"`
+	MechanismFound       bool     `protobuf:"varint,2,opt,name=mechanism_found,json=mechanismFound,proto3" json:"mechanism_found,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *EndpointConnectionInterfaceReply) Reset()         { *m = EndpointConnectionInterfaceReply{} }
-func (m *EndpointConnectionInterfaceReply) String() string { return proto.CompactTextString(m) }
-func (*EndpointConnectionInterfaceReply) ProtoMessage()    {}
-func (*EndpointConnectionInterfaceReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_f691f309118b0090, []int{3}
+func (m *EndpointConnectionMechanismReply) Reset()         { *m = EndpointConnectionMechanismReply{} }
+func (m *EndpointConnectionMechanismReply) String() string { return proto.CompactTextString(m) }
+func (*EndpointConnectionMechanismReply) ProtoMessage()    {}
+func (*EndpointConnectionMechanismReply) Descriptor() ([]byte, []int) {
+	return fileDescriptor_nseconnect_54fa9345bcf3911d, []int{3}
 }
-func (m *EndpointConnectionInterfaceReply) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_EndpointConnectionInterfaceReply.Unmarshal(m, b)
+func (m *EndpointConnectionMechanismReply) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_EndpointConnectionMechanismReply.Unmarshal(m, b)
 }
-func (m *EndpointConnectionInterfaceReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_EndpointConnectionInterfaceReply.Marshal(b, m, deterministic)
+func (m *EndpointConnectionMechanismReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_EndpointConnectionMechanismReply.Marshal(b, m, deterministic)
 }
-func (dst *EndpointConnectionInterfaceReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EndpointConnectionInterfaceReply.Merge(dst, src)
+func (dst *EndpointConnectionMechanismReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EndpointConnectionMechanismReply.Merge(dst, src)
 }
-func (m *EndpointConnectionInterfaceReply) XXX_Size() int {
-	return xxx_messageInfo_EndpointConnectionInterfaceReply.Size(m)
+func (m *EndpointConnectionMechanismReply) XXX_Size() int {
+	return xxx_messageInfo_EndpointConnectionMechanismReply.Size(m)
 }
-func (m *EndpointConnectionInterfaceReply) XXX_DiscardUnknown() {
-	xxx_messageInfo_EndpointConnectionInterfaceReply.DiscardUnknown(m)
+func (m *EndpointConnectionMechanismReply) XXX_DiscardUnknown() {
+	xxx_messageInfo_EndpointConnectionMechanismReply.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_EndpointConnectionInterfaceReply proto.InternalMessageInfo
+var xxx_messageInfo_EndpointConnectionMechanismReply proto.InternalMessageInfo
 
-func (m *EndpointConnectionInterfaceReply) GetRequestId() string {
+func (m *EndpointConnectionMechanismReply) GetRequestId() string {
 	if m != nil {
 		return m.RequestId
 	}
 	return ""
 }
 
-func (m *EndpointConnectionInterfaceReply) GetInterfaceFound() bool {
+func (m *EndpointConnectionMechanismReply) GetMechanismFound() bool {
 	if m != nil {
-		return m.InterfaceFound
+		return m.MechanismFound
 	}
 	return false
 }
@@ -243,7 +244,7 @@ func (m *EndpointAdvertiseRequest) Reset()         { *m = EndpointAdvertiseReque
 func (m *EndpointAdvertiseRequest) String() string { return proto.CompactTextString(m) }
 func (*EndpointAdvertiseRequest) ProtoMessage()    {}
 func (*EndpointAdvertiseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_f691f309118b0090, []int{4}
+	return fileDescriptor_nseconnect_54fa9345bcf3911d, []int{4}
 }
 func (m *EndpointAdvertiseRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointAdvertiseRequest.Unmarshal(m, b)
@@ -290,7 +291,7 @@ func (m *EndpointAdvertiseReply) Reset()         { *m = EndpointAdvertiseReply{}
 func (m *EndpointAdvertiseReply) String() string { return proto.CompactTextString(m) }
 func (*EndpointAdvertiseReply) ProtoMessage()    {}
 func (*EndpointAdvertiseReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_f691f309118b0090, []int{5}
+	return fileDescriptor_nseconnect_54fa9345bcf3911d, []int{5}
 }
 func (m *EndpointAdvertiseReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointAdvertiseReply.Unmarshal(m, b)
@@ -346,7 +347,7 @@ func (m *EndpointRemoveRequest) Reset()         { *m = EndpointRemoveRequest{} }
 func (m *EndpointRemoveRequest) String() string { return proto.CompactTextString(m) }
 func (*EndpointRemoveRequest) ProtoMessage()    {}
 func (*EndpointRemoveRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_f691f309118b0090, []int{6}
+	return fileDescriptor_nseconnect_54fa9345bcf3911d, []int{6}
 }
 func (m *EndpointRemoveRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointRemoveRequest.Unmarshal(m, b)
@@ -393,7 +394,7 @@ func (m *EndpointRemoveReply) Reset()         { *m = EndpointRemoveReply{} }
 func (m *EndpointRemoveReply) String() string { return proto.CompactTextString(m) }
 func (*EndpointRemoveReply) ProtoMessage()    {}
 func (*EndpointRemoveReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_f691f309118b0090, []int{7}
+	return fileDescriptor_nseconnect_54fa9345bcf3911d, []int{7}
 }
 func (m *EndpointRemoveReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointRemoveReply.Unmarshal(m, b)
@@ -437,8 +438,8 @@ func (m *EndpointRemoveReply) GetAdmissionError() string {
 func init() {
 	proto.RegisterType((*EndpointConnectionRequest)(nil), "nseconnect.EndpointConnectionRequest")
 	proto.RegisterType((*EndpointConnectionReply)(nil), "nseconnect.EndpointConnectionReply")
-	proto.RegisterType((*EndpointConnectionInterface)(nil), "nseconnect.EndpointConnectionInterface")
-	proto.RegisterType((*EndpointConnectionInterfaceReply)(nil), "nseconnect.EndpointConnectionInterfaceReply")
+	proto.RegisterType((*EndpointConnectionMechanism)(nil), "nseconnect.EndpointConnectionMechanism")
+	proto.RegisterType((*EndpointConnectionMechanismReply)(nil), "nseconnect.EndpointConnectionMechanismReply")
 	proto.RegisterType((*EndpointAdvertiseRequest)(nil), "nseconnect.EndpointAdvertiseRequest")
 	proto.RegisterType((*EndpointAdvertiseReply)(nil), "nseconnect.EndpointAdvertiseReply")
 	proto.RegisterType((*EndpointRemoveRequest)(nil), "nseconnect.EndpointRemoveRequest")
@@ -458,7 +459,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type EndpointConnectionClient interface {
 	RequestEndpointConnection(ctx context.Context, in *EndpointConnectionRequest, opts ...grpc.CallOption) (*EndpointConnectionReply, error)
-	SendEndpointConnectionInterface(ctx context.Context, in *EndpointConnectionInterface, opts ...grpc.CallOption) (*EndpointConnectionInterfaceReply, error)
+	SendEndpointConnectionMechanism(ctx context.Context, in *EndpointConnectionMechanism, opts ...grpc.CallOption) (*EndpointConnectionMechanismReply, error)
 }
 
 type endpointConnectionClient struct {
@@ -478,9 +479,9 @@ func (c *endpointConnectionClient) RequestEndpointConnection(ctx context.Context
 	return out, nil
 }
 
-func (c *endpointConnectionClient) SendEndpointConnectionInterface(ctx context.Context, in *EndpointConnectionInterface, opts ...grpc.CallOption) (*EndpointConnectionInterfaceReply, error) {
-	out := new(EndpointConnectionInterfaceReply)
-	err := c.cc.Invoke(ctx, "/nseconnect.EndpointConnection/SendEndpointConnectionInterface", in, out, opts...)
+func (c *endpointConnectionClient) SendEndpointConnectionMechanism(ctx context.Context, in *EndpointConnectionMechanism, opts ...grpc.CallOption) (*EndpointConnectionMechanismReply, error) {
+	out := new(EndpointConnectionMechanismReply)
+	err := c.cc.Invoke(ctx, "/nseconnect.EndpointConnection/SendEndpointConnectionMechanism", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -490,7 +491,7 @@ func (c *endpointConnectionClient) SendEndpointConnectionInterface(ctx context.C
 // EndpointConnectionServer is the server API for EndpointConnection service.
 type EndpointConnectionServer interface {
 	RequestEndpointConnection(context.Context, *EndpointConnectionRequest) (*EndpointConnectionReply, error)
-	SendEndpointConnectionInterface(context.Context, *EndpointConnectionInterface) (*EndpointConnectionInterfaceReply, error)
+	SendEndpointConnectionMechanism(context.Context, *EndpointConnectionMechanism) (*EndpointConnectionMechanismReply, error)
 }
 
 func RegisterEndpointConnectionServer(s *grpc.Server, srv EndpointConnectionServer) {
@@ -515,20 +516,20 @@ func _EndpointConnection_RequestEndpointConnection_Handler(srv interface{}, ctx 
 	return interceptor(ctx, in, info, handler)
 }
 
-func _EndpointConnection_SendEndpointConnectionInterface_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(EndpointConnectionInterface)
+func _EndpointConnection_SendEndpointConnectionMechanism_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EndpointConnectionMechanism)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(EndpointConnectionServer).SendEndpointConnectionInterface(ctx, in)
+		return srv.(EndpointConnectionServer).SendEndpointConnectionMechanism(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/nseconnect.EndpointConnection/SendEndpointConnectionInterface",
+		FullMethod: "/nseconnect.EndpointConnection/SendEndpointConnectionMechanism",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(EndpointConnectionServer).SendEndpointConnectionInterface(ctx, req.(*EndpointConnectionInterface))
+		return srv.(EndpointConnectionServer).SendEndpointConnectionMechanism(ctx, req.(*EndpointConnectionMechanism))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -542,8 +543,8 @@ var _EndpointConnection_serviceDesc = grpc.ServiceDesc{
 			Handler:    _EndpointConnection_RequestEndpointConnection_Handler,
 		},
 		{
-			MethodName: "SendEndpointConnectionInterface",
-			Handler:    _EndpointConnection_SendEndpointConnectionInterface_Handler,
+			MethodName: "SendEndpointConnectionMechanism",
+			Handler:    _EndpointConnection_SendEndpointConnectionMechanism_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -647,39 +648,41 @@ var _EndpointOperations_serviceDesc = grpc.ServiceDesc{
 	Metadata: "nseconnect.proto",
 }
 
-func init() { proto.RegisterFile("nseconnect.proto", fileDescriptor_nseconnect_f691f309118b0090) }
+func init() { proto.RegisterFile("nseconnect.proto", fileDescriptor_nseconnect_54fa9345bcf3911d) }
 
-var fileDescriptor_nseconnect_f691f309118b0090 = []byte{
-	// 491 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x54, 0x4d, 0x6f, 0x13, 0x31,
-	0x10, 0xd5, 0x52, 0x09, 0xb5, 0x83, 0x48, 0x8a, 0xf9, 0x4a, 0x17, 0xa1, 0x94, 0x85, 0x2a, 0x1c,
-	0x50, 0x16, 0x85, 0x5f, 0x80, 0x50, 0x41, 0xe5, 0x10, 0xa4, 0x94, 0x2b, 0x8a, 0xdc, 0xdd, 0x69,
-	0x6a, 0xba, 0x6b, 0x1b, 0xdb, 0x09, 0x8d, 0xc4, 0x09, 0x89, 0x5f, 0x80, 0xf8, 0x51, 0xfc, 0x22,
-	0xae, 0x68, 0xbd, 0xf6, 0x26, 0x6d, 0x36, 0x1f, 0x07, 0x44, 0x4f, 0x49, 0xde, 0x3c, 0xcf, 0x7b,
-	0x6f, 0x32, 0x36, 0xec, 0x72, 0x8d, 0x89, 0xe0, 0x1c, 0x13, 0xd3, 0x95, 0x4a, 0x18, 0x41, 0x60,
-	0x86, 0x84, 0xef, 0x46, 0xcc, 0x9c, 0x8d, 0x4f, 0xba, 0x89, 0xc8, 0xe3, 0x8c, 0x8d, 0xa8, 0x11,
-	0x31, 0x47, 0xf3, 0x55, 0xa8, 0x73, 0x8d, 0x6a, 0xc2, 0x12, 0xcc, 0x51, 0x9f, 0xc5, 0xf2, 0x7c,
-	0x14, 0x73, 0x9d, 0xc7, 0x54, 0x32, 0x5d, 0xd4, 0x2d, 0xe8, 0x3e, 0xcb, 0xa6, 0x51, 0x06, 0x7b,
-	0x87, 0x3c, 0x95, 0x82, 0x71, 0xf3, 0xa6, 0xec, 0xcd, 0x04, 0x1f, 0xe0, 0x97, 0x31, 0x6a, 0x43,
-	0x1e, 0x03, 0xa8, 0xf2, 0xeb, 0x90, 0xa5, 0xad, 0x60, 0x3f, 0x78, 0xbe, 0x33, 0xd8, 0x71, 0xc8,
-	0x51, 0x4a, 0x5e, 0xc2, 0x3d, 0x27, 0x3a, 0x74, 0xaa, 0x43, 0x4e, 0x73, 0x6c, 0xdd, 0xb0, 0x44,
-	0xe2, 0x6a, 0xc7, 0x65, 0xa9, 0x4f, 0x73, 0x8c, 0x7e, 0x06, 0xf0, 0xb0, 0x4e, 0x4e, 0x66, 0xd3,
-	0x7f, 0x2e, 0x46, 0x3a, 0xd0, 0xcc, 0x18, 0x1f, 0x5f, 0x58, 0x9e, 0x96, 0x34, 0xc1, 0xd6, 0x96,
-	0x25, 0x37, 0x2c, 0xdc, 0xf7, 0x68, 0xf4, 0x2b, 0x80, 0x47, 0x8b, 0xae, 0x8e, 0xb8, 0x41, 0x75,
-	0x4a, 0x13, 0x5c, 0xe7, 0xec, 0x00, 0x1a, 0xcc, 0x73, 0xe7, 0x3d, 0xdd, 0xae, 0x50, 0x6b, 0x67,
-	0x59, 0x80, 0xad, 0xa5, 0xd3, 0xfa, 0x0c, 0xfb, 0x2b, 0x6c, 0x6d, 0x34, 0xb5, 0x0e, 0x34, 0x67,
-	0xde, 0x4e, 0xc5, 0x98, 0xa7, 0xd6, 0xdc, 0xf6, 0x60, 0x66, 0xf9, 0x6d, 0x81, 0x46, 0x3f, 0x02,
-	0x68, 0x79, 0xb1, 0xd7, 0xe9, 0x04, 0x95, 0x61, 0x1a, 0x37, 0xdc, 0x83, 0xf7, 0xb0, 0xeb, 0x93,
-	0xa1, 0x6b, 0x61, 0x55, 0x6e, 0xf5, 0xda, 0x5d, 0xbf, 0x6d, 0xfd, 0x4b, 0xf1, 0xbc, 0xd2, 0xa0,
-	0xe9, 0x0e, 0x7a, 0x20, 0xfa, 0x06, 0x0f, 0x6a, 0x6c, 0x6c, 0x90, 0x34, 0x84, 0x6d, 0x9a, 0x24,
-	0x28, 0x0d, 0xfa, 0x88, 0xd5, 0xef, 0x62, 0x0a, 0x34, 0xcd, 0x99, 0xd6, 0x4c, 0xf0, 0x21, 0x2a,
-	0x25, 0x94, 0xdf, 0x84, 0x0a, 0x3e, 0x2c, 0xd0, 0xe8, 0x7b, 0x00, 0xf7, 0x2b, 0x6f, 0x98, 0x8b,
-	0xc9, 0x75, 0x8c, 0x60, 0x0a, 0x77, 0xaf, 0x7a, 0xf8, 0x4f, 0xf9, 0x7b, 0x7f, 0x02, 0x20, 0x8b,
-	0x2b, 0x47, 0x46, 0xb0, 0xe7, 0xe6, 0x50, 0x53, 0x3c, 0xe8, 0xce, 0xbd, 0x54, 0x4b, 0xdf, 0x92,
-	0xf0, 0xe9, 0x3a, 0x5a, 0x91, 0xf1, 0x02, 0xda, 0xc7, 0xc8, 0xd3, 0x55, 0x97, 0xb1, 0xb3, 0xba,
-	0x4f, 0x45, 0x0c, 0x5f, 0x6c, 0x48, 0xb4, 0xca, 0xbd, 0xdf, 0x73, 0xc9, 0x3f, 0x48, 0x54, 0xb4,
-	0xe0, 0x68, 0xf2, 0x09, 0xee, 0x54, 0x6b, 0xe8, 0xcb, 0xe4, 0x59, 0x5d, 0xe7, 0xab, 0x97, 0x26,
-	0x8c, 0xd6, 0xb0, 0x8a, 0xbc, 0x1f, 0xa1, 0x51, 0xfe, 0xc5, 0x55, 0xef, 0x27, 0x75, 0xa7, 0x2e,
-	0xad, 0x62, 0xd8, 0x5e, 0x45, 0x91, 0xd9, 0xf4, 0xe4, 0xa6, 0x7d, 0xda, 0x5f, 0xfd, 0x0d, 0x00,
-	0x00, 0xff, 0xff, 0x62, 0x4e, 0x3f, 0xdf, 0x43, 0x06, 0x00, 0x00,
+var fileDescriptor_nseconnect_54fa9345bcf3911d = []byte{
+	// 519 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x54, 0xdd, 0x8a, 0xd3, 0x40,
+	0x14, 0x26, 0x2e, 0xc8, 0xee, 0x11, 0xda, 0x35, 0xea, 0xda, 0x8d, 0x48, 0xd7, 0xa8, 0xd4, 0x0b,
+	0x69, 0xa4, 0x3e, 0x80, 0x88, 0x54, 0x51, 0xb4, 0x42, 0xd6, 0x5b, 0x09, 0xb3, 0x93, 0x63, 0x3b,
+	0x6e, 0x66, 0x26, 0x66, 0xd2, 0xba, 0x05, 0xaf, 0x04, 0x9f, 0xc0, 0x07, 0xf1, 0x39, 0x7c, 0x22,
+	0x6f, 0x25, 0x93, 0x99, 0x71, 0xbb, 0x9b, 0xfe, 0x08, 0xe2, 0x5e, 0xa5, 0xf9, 0xce, 0x37, 0xdf,
+	0xf9, 0xbe, 0xd3, 0x93, 0x81, 0x5d, 0xa1, 0x90, 0x4a, 0x21, 0x90, 0x96, 0xfd, 0xbc, 0x90, 0xa5,
+	0xf4, 0xe1, 0x0f, 0x12, 0xbc, 0x18, 0xb3, 0x72, 0x32, 0x3d, 0xea, 0x53, 0xc9, 0xa3, 0x8c, 0x8d,
+	0x49, 0x29, 0x23, 0x81, 0xe5, 0x67, 0x59, 0x1c, 0x2b, 0x2c, 0x66, 0x8c, 0x22, 0x47, 0x35, 0x89,
+	0xf2, 0xe3, 0x71, 0x24, 0x14, 0x8f, 0x48, 0xce, 0x54, 0x55, 0xd7, 0xa0, 0x79, 0xd6, 0xa2, 0xc1,
+	0xf0, 0xef, 0x85, 0xa8, 0xe4, 0x5c, 0x0a, 0xf3, 0xa8, 0x65, 0xc2, 0x0c, 0xf6, 0x87, 0x22, 0xcd,
+	0x25, 0x13, 0xe5, 0xb3, 0xda, 0x22, 0x93, 0x22, 0xc6, 0x4f, 0x53, 0x54, 0xa5, 0x7f, 0x1b, 0xa0,
+	0xa8, 0x7f, 0x26, 0x2c, 0xed, 0x78, 0x07, 0xde, 0x83, 0x9d, 0x78, 0xc7, 0x20, 0x2f, 0x53, 0xff,
+	0x11, 0x5c, 0x37, 0x2d, 0x13, 0xd3, 0x33, 0x11, 0x84, 0x63, 0xe7, 0x92, 0x26, 0xfa, 0xa6, 0x76,
+	0x58, 0x97, 0x46, 0x84, 0x63, 0xf8, 0xdd, 0x83, 0x9b, 0x4d, 0xed, 0xf2, 0x6c, 0xfe, 0xcf, 0x9b,
+	0xf9, 0x3d, 0x68, 0x67, 0x4c, 0x4c, 0x4f, 0x34, 0x4f, 0xe5, 0x84, 0x62, 0x67, 0x4b, 0x93, 0x5b,
+	0x1a, 0x1e, 0x59, 0x34, 0xfc, 0xe1, 0xc1, 0xad, 0xf3, 0xae, 0xde, 0x20, 0x9d, 0x10, 0xc1, 0x14,
+	0x5f, 0xe7, 0xec, 0x09, 0xb4, 0x33, 0x49, 0x49, 0x96, 0x70, 0x7b, 0x42, 0x9b, 0xba, 0x32, 0xd8,
+	0xeb, 0x9b, 0x51, 0xbf, 0xae, 0xca, 0x4e, 0x2f, 0x6e, 0x65, 0x0b, 0xef, 0x4b, 0xa3, 0x6d, 0x2d,
+	0x9d, 0xe3, 0x47, 0x38, 0x58, 0x61, 0x78, 0xa3, 0x79, 0xf6, 0xa0, 0xed, 0xfc, 0x26, 0x1f, 0xe4,
+	0x54, 0xa4, 0xda, 0xf5, 0x76, 0xdc, 0x72, 0xf0, 0xf3, 0x0a, 0x0d, 0xbf, 0x79, 0xd0, 0xb1, 0xcd,
+	0x9e, 0xa6, 0x33, 0x2c, 0x4a, 0xa6, 0x70, 0xc3, 0x0d, 0x79, 0x05, 0xbb, 0x36, 0x19, 0x1a, 0x09,
+	0x33, 0x9b, 0x6e, 0xdf, 0xae, 0xf3, 0x68, 0x21, 0x9e, 0xed, 0x14, 0xb7, 0xcd, 0x41, 0x0b, 0x84,
+	0x5f, 0x60, 0xaf, 0xc1, 0xc6, 0x06, 0x49, 0x03, 0xd8, 0x26, 0x94, 0x62, 0x5e, 0xa2, 0x8d, 0xe8,
+	0xde, 0xab, 0x29, 0x90, 0x94, 0x33, 0xa5, 0x98, 0x14, 0x09, 0x16, 0x85, 0x2c, 0xec, 0x8e, 0x38,
+	0x78, 0x58, 0xa1, 0xe1, 0x57, 0x0f, 0x6e, 0x38, 0x6f, 0xc8, 0xe5, 0xec, 0x22, 0x46, 0x30, 0x87,
+	0x6b, 0x67, 0x3d, 0xfc, 0xa7, 0xfc, 0x83, 0x5f, 0x1e, 0xf8, 0xe7, 0x57, 0xce, 0x1f, 0xc3, 0xbe,
+	0x99, 0x43, 0x43, 0xf1, 0x7e, 0xff, 0xd4, 0x55, 0xb8, 0xf4, 0x96, 0x09, 0xee, 0xae, 0xa3, 0x55,
+	0x19, 0x4f, 0xa0, 0x7b, 0x88, 0x22, 0x5d, 0xf5, 0x99, 0xf6, 0x56, 0xeb, 0x38, 0x62, 0xf0, 0x70,
+	0x43, 0xa2, 0xee, 0x3c, 0xf8, 0x79, 0x2a, 0xf9, 0xdb, 0x1c, 0x0b, 0x52, 0x71, 0x94, 0xff, 0x1e,
+	0xae, 0xba, 0x35, 0xb4, 0x65, 0xff, 0x5e, 0x93, 0xf2, 0xd9, 0x8f, 0x26, 0x08, 0xd7, 0xb0, 0xaa,
+	0xbc, 0xef, 0xa0, 0x55, 0xff, 0xc5, 0x4e, 0xfb, 0x4e, 0xd3, 0xa9, 0x85, 0x55, 0x0c, 0xba, 0xab,
+	0x28, 0x79, 0x36, 0x3f, 0xba, 0xac, 0x2f, 0xfd, 0xc7, 0xbf, 0x03, 0x00, 0x00, 0xff, 0xff, 0xce,
+	0x65, 0x5c, 0xee, 0xa4, 0x06, 0x00, 0x00,
 }

--- a/pkg/nsm/apis/nseconnect/nseconnect.pb.go
+++ b/pkg/nsm/apis/nseconnect/nseconnect.pb.go
@@ -26,8 +26,8 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 // EndpointConnectionRequest is sent by a NSM to NSE to build a connection.
 type EndpointConnectionRequest struct {
-	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	NetworkServiceName   string   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName" json:"network_service_name,omitempty"`
+	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NetworkServiceName   string   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -37,7 +37,7 @@ func (m *EndpointConnectionRequest) Reset()         { *m = EndpointConnectionReq
 func (m *EndpointConnectionRequest) String() string { return proto.CompactTextString(m) }
 func (*EndpointConnectionRequest) ProtoMessage()    {}
 func (*EndpointConnectionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_d3bee6930b5b72db, []int{0}
+	return fileDescriptor_nseconnect_f691f309118b0090, []int{0}
 }
 func (m *EndpointConnectionRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointConnectionRequest.Unmarshal(m, b)
@@ -74,9 +74,9 @@ func (m *EndpointConnectionRequest) GetNetworkServiceName() string {
 // EndpointConnectionReply is sent back by NSE to NSM with information required for
 // dataplane programming.
 type EndpointConnectionReply struct {
-	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	NetworkServiceName   string   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName" json:"network_service_name,omitempty"`
-	LinuxNamespace       string   `protobuf:"bytes,3,opt,name=linux_namespace,json=linuxNamespace" json:"linux_namespace,omitempty"`
+	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NetworkServiceName   string   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
+	LinuxNamespace       string   `protobuf:"bytes,3,opt,name=linux_namespace,json=linuxNamespace,proto3" json:"linux_namespace,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -86,7 +86,7 @@ func (m *EndpointConnectionReply) Reset()         { *m = EndpointConnectionReply
 func (m *EndpointConnectionReply) String() string { return proto.CompactTextString(m) }
 func (*EndpointConnectionReply) ProtoMessage()    {}
 func (*EndpointConnectionReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_d3bee6930b5b72db, []int{1}
+	return fileDescriptor_nseconnect_f691f309118b0090, []int{1}
 }
 func (m *EndpointConnectionReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointConnectionReply.Unmarshal(m, b)
@@ -127,9 +127,113 @@ func (m *EndpointConnectionReply) GetLinuxNamespace() string {
 	return ""
 }
 
+// EndpointConnectionInterface is sent by a NSM to NSE to inform NSE about
+// the interface name which was created by the dataplane controller.
+type EndpointConnectionInterface struct {
+	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	InterfaceName        string   `protobuf:"bytes,2,opt,name=interface_name,json=interfaceName,proto3" json:"interface_name,omitempty"`
+	NetworkServiceName   string   `protobuf:"bytes,3,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *EndpointConnectionInterface) Reset()         { *m = EndpointConnectionInterface{} }
+func (m *EndpointConnectionInterface) String() string { return proto.CompactTextString(m) }
+func (*EndpointConnectionInterface) ProtoMessage()    {}
+func (*EndpointConnectionInterface) Descriptor() ([]byte, []int) {
+	return fileDescriptor_nseconnect_f691f309118b0090, []int{2}
+}
+func (m *EndpointConnectionInterface) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_EndpointConnectionInterface.Unmarshal(m, b)
+}
+func (m *EndpointConnectionInterface) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_EndpointConnectionInterface.Marshal(b, m, deterministic)
+}
+func (dst *EndpointConnectionInterface) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EndpointConnectionInterface.Merge(dst, src)
+}
+func (m *EndpointConnectionInterface) XXX_Size() int {
+	return xxx_messageInfo_EndpointConnectionInterface.Size(m)
+}
+func (m *EndpointConnectionInterface) XXX_DiscardUnknown() {
+	xxx_messageInfo_EndpointConnectionInterface.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_EndpointConnectionInterface proto.InternalMessageInfo
+
+func (m *EndpointConnectionInterface) GetRequestId() string {
+	if m != nil {
+		return m.RequestId
+	}
+	return ""
+}
+
+func (m *EndpointConnectionInterface) GetInterfaceName() string {
+	if m != nil {
+		return m.InterfaceName
+	}
+	return ""
+}
+
+func (m *EndpointConnectionInterface) GetNetworkServiceName() string {
+	if m != nil {
+		return m.NetworkServiceName
+	}
+	return ""
+}
+
+// EndpointConnectionInterfaceReply is sent back by NSE to NSM to confirm the presence
+// of the programmed interface.
+type EndpointConnectionInterfaceReply struct {
+	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	InterfaceFound       bool     `protobuf:"varint,2,opt,name=interface_found,json=interfaceFound,proto3" json:"interface_found,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *EndpointConnectionInterfaceReply) Reset()         { *m = EndpointConnectionInterfaceReply{} }
+func (m *EndpointConnectionInterfaceReply) String() string { return proto.CompactTextString(m) }
+func (*EndpointConnectionInterfaceReply) ProtoMessage()    {}
+func (*EndpointConnectionInterfaceReply) Descriptor() ([]byte, []int) {
+	return fileDescriptor_nseconnect_f691f309118b0090, []int{3}
+}
+func (m *EndpointConnectionInterfaceReply) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_EndpointConnectionInterfaceReply.Unmarshal(m, b)
+}
+func (m *EndpointConnectionInterfaceReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_EndpointConnectionInterfaceReply.Marshal(b, m, deterministic)
+}
+func (dst *EndpointConnectionInterfaceReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EndpointConnectionInterfaceReply.Merge(dst, src)
+}
+func (m *EndpointConnectionInterfaceReply) XXX_Size() int {
+	return xxx_messageInfo_EndpointConnectionInterfaceReply.Size(m)
+}
+func (m *EndpointConnectionInterfaceReply) XXX_DiscardUnknown() {
+	xxx_messageInfo_EndpointConnectionInterfaceReply.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_EndpointConnectionInterfaceReply proto.InternalMessageInfo
+
+func (m *EndpointConnectionInterfaceReply) GetRequestId() string {
+	if m != nil {
+		return m.RequestId
+	}
+	return ""
+}
+
+func (m *EndpointConnectionInterfaceReply) GetInterfaceFound() bool {
+	if m != nil {
+		return m.InterfaceFound
+	}
+	return false
+}
+
 type EndpointAdvertiseRequest struct {
-	RequestId            string                          `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	NetworkEndpoint      *netmesh.NetworkServiceEndpoint `protobuf:"bytes,2,opt,name=network_endpoint,json=networkEndpoint" json:"network_endpoint,omitempty"`
+	RequestId            string                          `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NetworkEndpoint      *netmesh.NetworkServiceEndpoint `protobuf:"bytes,2,opt,name=network_endpoint,json=networkEndpoint,proto3" json:"network_endpoint,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                        `json:"-"`
 	XXX_unrecognized     []byte                          `json:"-"`
 	XXX_sizecache        int32                           `json:"-"`
@@ -139,7 +243,7 @@ func (m *EndpointAdvertiseRequest) Reset()         { *m = EndpointAdvertiseReque
 func (m *EndpointAdvertiseRequest) String() string { return proto.CompactTextString(m) }
 func (*EndpointAdvertiseRequest) ProtoMessage()    {}
 func (*EndpointAdvertiseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_d3bee6930b5b72db, []int{2}
+	return fileDescriptor_nseconnect_f691f309118b0090, []int{4}
 }
 func (m *EndpointAdvertiseRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointAdvertiseRequest.Unmarshal(m, b)
@@ -174,9 +278,9 @@ func (m *EndpointAdvertiseRequest) GetNetworkEndpoint() *netmesh.NetworkServiceE
 }
 
 type EndpointAdvertiseReply struct {
-	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	Accepted             bool     `protobuf:"varint,2,opt,name=accepted" json:"accepted,omitempty"`
-	AdmissionError       string   `protobuf:"bytes,3,opt,name=admission_error,json=admissionError" json:"admission_error,omitempty"`
+	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	Accepted             bool     `protobuf:"varint,2,opt,name=accepted,proto3" json:"accepted,omitempty"`
+	AdmissionError       string   `protobuf:"bytes,3,opt,name=admission_error,json=admissionError,proto3" json:"admission_error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -186,7 +290,7 @@ func (m *EndpointAdvertiseReply) Reset()         { *m = EndpointAdvertiseReply{}
 func (m *EndpointAdvertiseReply) String() string { return proto.CompactTextString(m) }
 func (*EndpointAdvertiseReply) ProtoMessage()    {}
 func (*EndpointAdvertiseReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_d3bee6930b5b72db, []int{3}
+	return fileDescriptor_nseconnect_f691f309118b0090, []int{5}
 }
 func (m *EndpointAdvertiseReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointAdvertiseReply.Unmarshal(m, b)
@@ -231,8 +335,8 @@ func (m *EndpointAdvertiseReply) GetAdmissionError() string {
 // endpoint. NSM will attempt to locate Customer Resource and delete it.
 //
 type EndpointRemoveRequest struct {
-	RequestId            string                          `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	NetworkEndpoint      *netmesh.NetworkServiceEndpoint `protobuf:"bytes,2,opt,name=network_endpoint,json=networkEndpoint" json:"network_endpoint,omitempty"`
+	RequestId            string                          `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NetworkEndpoint      *netmesh.NetworkServiceEndpoint `protobuf:"bytes,2,opt,name=network_endpoint,json=networkEndpoint,proto3" json:"network_endpoint,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                        `json:"-"`
 	XXX_unrecognized     []byte                          `json:"-"`
 	XXX_sizecache        int32                           `json:"-"`
@@ -242,7 +346,7 @@ func (m *EndpointRemoveRequest) Reset()         { *m = EndpointRemoveRequest{} }
 func (m *EndpointRemoveRequest) String() string { return proto.CompactTextString(m) }
 func (*EndpointRemoveRequest) ProtoMessage()    {}
 func (*EndpointRemoveRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_d3bee6930b5b72db, []int{4}
+	return fileDescriptor_nseconnect_f691f309118b0090, []int{6}
 }
 func (m *EndpointRemoveRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointRemoveRequest.Unmarshal(m, b)
@@ -277,9 +381,9 @@ func (m *EndpointRemoveRequest) GetNetworkEndpoint() *netmesh.NetworkServiceEndp
 }
 
 type EndpointRemoveReply struct {
-	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	Accepted             bool     `protobuf:"varint,2,opt,name=accepted" json:"accepted,omitempty"`
-	AdmissionError       string   `protobuf:"bytes,3,opt,name=admission_error,json=admissionError" json:"admission_error,omitempty"`
+	RequestId            string   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	Accepted             bool     `protobuf:"varint,2,opt,name=accepted,proto3" json:"accepted,omitempty"`
+	AdmissionError       string   `protobuf:"bytes,3,opt,name=admission_error,json=admissionError,proto3" json:"admission_error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -289,7 +393,7 @@ func (m *EndpointRemoveReply) Reset()         { *m = EndpointRemoveReply{} }
 func (m *EndpointRemoveReply) String() string { return proto.CompactTextString(m) }
 func (*EndpointRemoveReply) ProtoMessage()    {}
 func (*EndpointRemoveReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_nseconnect_d3bee6930b5b72db, []int{5}
+	return fileDescriptor_nseconnect_f691f309118b0090, []int{7}
 }
 func (m *EndpointRemoveReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EndpointRemoveReply.Unmarshal(m, b)
@@ -333,6 +437,8 @@ func (m *EndpointRemoveReply) GetAdmissionError() string {
 func init() {
 	proto.RegisterType((*EndpointConnectionRequest)(nil), "nseconnect.EndpointConnectionRequest")
 	proto.RegisterType((*EndpointConnectionReply)(nil), "nseconnect.EndpointConnectionReply")
+	proto.RegisterType((*EndpointConnectionInterface)(nil), "nseconnect.EndpointConnectionInterface")
+	proto.RegisterType((*EndpointConnectionInterfaceReply)(nil), "nseconnect.EndpointConnectionInterfaceReply")
 	proto.RegisterType((*EndpointAdvertiseRequest)(nil), "nseconnect.EndpointAdvertiseRequest")
 	proto.RegisterType((*EndpointAdvertiseReply)(nil), "nseconnect.EndpointAdvertiseReply")
 	proto.RegisterType((*EndpointRemoveRequest)(nil), "nseconnect.EndpointRemoveRequest")
@@ -352,6 +458,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type EndpointConnectionClient interface {
 	RequestEndpointConnection(ctx context.Context, in *EndpointConnectionRequest, opts ...grpc.CallOption) (*EndpointConnectionReply, error)
+	SendEndpointConnectionInterface(ctx context.Context, in *EndpointConnectionInterface, opts ...grpc.CallOption) (*EndpointConnectionInterfaceReply, error)
 }
 
 type endpointConnectionClient struct {
@@ -371,10 +478,19 @@ func (c *endpointConnectionClient) RequestEndpointConnection(ctx context.Context
 	return out, nil
 }
 
-// Server API for EndpointConnection service
+func (c *endpointConnectionClient) SendEndpointConnectionInterface(ctx context.Context, in *EndpointConnectionInterface, opts ...grpc.CallOption) (*EndpointConnectionInterfaceReply, error) {
+	out := new(EndpointConnectionInterfaceReply)
+	err := c.cc.Invoke(ctx, "/nseconnect.EndpointConnection/SendEndpointConnectionInterface", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
 
+// EndpointConnectionServer is the server API for EndpointConnection service.
 type EndpointConnectionServer interface {
 	RequestEndpointConnection(context.Context, *EndpointConnectionRequest) (*EndpointConnectionReply, error)
+	SendEndpointConnectionInterface(context.Context, *EndpointConnectionInterface) (*EndpointConnectionInterfaceReply, error)
 }
 
 func RegisterEndpointConnectionServer(s *grpc.Server, srv EndpointConnectionServer) {
@@ -399,6 +515,24 @@ func _EndpointConnection_RequestEndpointConnection_Handler(srv interface{}, ctx 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _EndpointConnection_SendEndpointConnectionInterface_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EndpointConnectionInterface)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EndpointConnectionServer).SendEndpointConnectionInterface(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/nseconnect.EndpointConnection/SendEndpointConnectionInterface",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EndpointConnectionServer).SendEndpointConnectionInterface(ctx, req.(*EndpointConnectionInterface))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _EndpointConnection_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "nseconnect.EndpointConnection",
 	HandlerType: (*EndpointConnectionServer)(nil),
@@ -406,6 +540,10 @@ var _EndpointConnection_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RequestEndpointConnection",
 			Handler:    _EndpointConnection_RequestEndpointConnection_Handler,
+		},
+		{
+			MethodName: "SendEndpointConnectionInterface",
+			Handler:    _EndpointConnection_SendEndpointConnectionInterface_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -446,8 +584,7 @@ func (c *endpointOperationsClient) RemoveEndpoint(ctx context.Context, in *Endpo
 	return out, nil
 }
 
-// Server API for EndpointOperations service
-
+// EndpointOperationsServer is the server API for EndpointOperations service.
 type EndpointOperationsServer interface {
 	AdvertiseEndpoint(context.Context, *EndpointAdvertiseRequest) (*EndpointAdvertiseReply, error)
 	RemoveEndpoint(context.Context, *EndpointRemoveRequest) (*EndpointRemoveReply, error)
@@ -510,34 +647,39 @@ var _EndpointOperations_serviceDesc = grpc.ServiceDesc{
 	Metadata: "nseconnect.proto",
 }
 
-func init() { proto.RegisterFile("nseconnect.proto", fileDescriptor_nseconnect_d3bee6930b5b72db) }
+func init() { proto.RegisterFile("nseconnect.proto", fileDescriptor_nseconnect_f691f309118b0090) }
 
-var fileDescriptor_nseconnect_d3bee6930b5b72db = []byte{
-	// 412 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x54, 0xdd, 0x8a, 0xd3, 0x40,
-	0x18, 0x25, 0x0a, 0xb2, 0xfb, 0x09, 0xbb, 0xeb, 0xf8, 0x97, 0x0d, 0xc8, 0x6a, 0x54, 0xf4, 0x2a,
-	0x91, 0xfa, 0x04, 0x22, 0x45, 0xf4, 0xa2, 0x42, 0xf4, 0x56, 0xc2, 0x34, 0xf9, 0x48, 0x87, 0x26,
-	0x33, 0xe3, 0xcc, 0xb4, 0x1a, 0xd0, 0x1b, 0xc1, 0x27, 0xf0, 0xa9, 0x7c, 0x2b, 0xc9, 0x64, 0x26,
-	0xb5, 0x35, 0xda, 0x5e, 0x88, 0x5e, 0xb5, 0x39, 0xe7, 0xcc, 0x77, 0x4e, 0x0e, 0xdf, 0x04, 0xce,
-	0xb8, 0xc6, 0x42, 0x70, 0x8e, 0x85, 0x49, 0xa4, 0x12, 0x46, 0x10, 0xd8, 0x20, 0xd1, 0x8b, 0x8a,
-	0x99, 0xc5, 0x6a, 0x9e, 0x14, 0xa2, 0x49, 0x6b, 0x56, 0x51, 0x23, 0x52, 0x8e, 0xe6, 0x83, 0x50,
-	0x4b, 0x8d, 0x6a, 0xcd, 0x0a, 0x6c, 0x50, 0x2f, 0x52, 0xb9, 0xac, 0x52, 0xae, 0x9b, 0x94, 0x4a,
-	0xa6, 0x3b, 0xde, 0x82, 0xee, 0xb7, 0x1f, 0x1a, 0xd7, 0x70, 0x3e, 0xe5, 0xa5, 0x14, 0x8c, 0x9b,
-	0xe7, 0xfd, 0x6c, 0x26, 0x78, 0x86, 0xef, 0x57, 0xa8, 0x0d, 0xb9, 0x03, 0xa0, 0xfa, 0xbf, 0x39,
-	0x2b, 0xc3, 0xe0, 0x6e, 0xf0, 0xf8, 0x38, 0x3b, 0x76, 0xc8, 0xcb, 0x92, 0x3c, 0x81, 0x1b, 0xce,
-	0x34, 0x77, 0xae, 0x39, 0xa7, 0x0d, 0x86, 0x97, 0xac, 0x90, 0x38, 0xee, 0x4d, 0x4f, 0xcd, 0x68,
-	0x83, 0xf1, 0xb7, 0x00, 0x6e, 0x8f, 0xd9, 0xc9, 0xba, 0xfd, 0xeb, 0x66, 0xe4, 0x11, 0x9c, 0xd6,
-	0x8c, 0xaf, 0x3e, 0x5a, 0x9d, 0x96, 0xb4, 0xc0, 0xf0, 0xb2, 0x15, 0x9f, 0x58, 0x78, 0xe6, 0xd1,
-	0xf8, 0x6b, 0x00, 0xa1, 0x4f, 0xf5, 0xac, 0x5c, 0xa3, 0x32, 0x4c, 0xe3, 0x81, 0x1d, 0xbc, 0x82,
-	0x33, 0x1f, 0x0b, 0xdd, 0x08, 0x1b, 0xe9, 0xea, 0xe4, 0x22, 0xf1, 0x4d, 0xcf, 0xb6, 0xb2, 0x79,
-	0xa7, 0xec, 0xd4, 0x1d, 0xf4, 0x40, 0xfc, 0x09, 0x6e, 0x8d, 0xc4, 0x38, 0xa0, 0x9b, 0x08, 0x8e,
-	0x68, 0x51, 0xa0, 0x34, 0x58, 0x5a, 0xf3, 0xa3, 0x6c, 0x78, 0xee, 0x5a, 0xa0, 0x65, 0xc3, 0xb4,
-	0x66, 0x82, 0xe7, 0xa8, 0x94, 0x50, 0xbe, 0x85, 0x01, 0x9e, 0x76, 0x68, 0xfc, 0x25, 0x80, 0x9b,
-	0x43, 0x36, 0x6c, 0xc4, 0xfa, 0x7f, 0x54, 0xd0, 0xc2, 0xf5, 0xdd, 0x0c, 0xff, 0xe8, 0xfd, 0x27,
-	0x9f, 0x81, 0xfc, 0xba, 0x9a, 0xa4, 0x82, 0x73, 0x57, 0xc3, 0x08, 0xf9, 0x30, 0xf9, 0xe9, 0x92,
-	0xfe, 0xf6, 0x1a, 0x45, 0xf7, 0xf7, 0xc9, 0x64, 0xdd, 0x4e, 0xbe, 0x07, 0x1b, 0xff, 0xd7, 0x12,
-	0x15, 0xed, 0x28, 0x4d, 0xde, 0xc1, 0xb5, 0x61, 0x17, 0x3c, 0x4d, 0x1e, 0x8c, 0x0d, 0xdc, 0xdd,
-	0xdc, 0x28, 0xde, 0xa3, 0xea, 0x8a, 0x7d, 0x0b, 0x27, 0x7d, 0xcf, 0xc3, 0xec, 0x7b, 0x63, 0xa7,
-	0xb6, 0xf6, 0x21, 0xba, 0xf8, 0x93, 0x44, 0xd6, 0xed, 0xfc, 0x8a, 0xfd, 0xb6, 0x3c, 0xfd, 0x11,
-	0x00, 0x00, 0xff, 0xff, 0xd8, 0xb0, 0x54, 0x06, 0xc4, 0x04, 0x00, 0x00,
+var fileDescriptor_nseconnect_f691f309118b0090 = []byte{
+	// 491 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x54, 0x4d, 0x6f, 0x13, 0x31,
+	0x10, 0xd5, 0x52, 0x09, 0xb5, 0x83, 0x48, 0x8a, 0xf9, 0x4a, 0x17, 0xa1, 0x94, 0x85, 0x2a, 0x1c,
+	0x50, 0x16, 0x85, 0x5f, 0x80, 0x50, 0x41, 0xe5, 0x10, 0xa4, 0x94, 0x2b, 0x8a, 0xdc, 0xdd, 0x69,
+	0x6a, 0xba, 0x6b, 0x1b, 0xdb, 0x09, 0x8d, 0xc4, 0x09, 0x89, 0x5f, 0x80, 0xf8, 0x51, 0xfc, 0x22,
+	0xae, 0x68, 0xbd, 0xf6, 0x26, 0x6d, 0x36, 0x1f, 0x07, 0x44, 0x4f, 0x49, 0xde, 0x3c, 0xcf, 0x7b,
+	0x6f, 0x32, 0x36, 0xec, 0x72, 0x8d, 0x89, 0xe0, 0x1c, 0x13, 0xd3, 0x95, 0x4a, 0x18, 0x41, 0x60,
+	0x86, 0x84, 0xef, 0x46, 0xcc, 0x9c, 0x8d, 0x4f, 0xba, 0x89, 0xc8, 0xe3, 0x8c, 0x8d, 0xa8, 0x11,
+	0x31, 0x47, 0xf3, 0x55, 0xa8, 0x73, 0x8d, 0x6a, 0xc2, 0x12, 0xcc, 0x51, 0x9f, 0xc5, 0xf2, 0x7c,
+	0x14, 0x73, 0x9d, 0xc7, 0x54, 0x32, 0x5d, 0xd4, 0x2d, 0xe8, 0x3e, 0xcb, 0xa6, 0x51, 0x06, 0x7b,
+	0x87, 0x3c, 0x95, 0x82, 0x71, 0xf3, 0xa6, 0xec, 0xcd, 0x04, 0x1f, 0xe0, 0x97, 0x31, 0x6a, 0x43,
+	0x1e, 0x03, 0xa8, 0xf2, 0xeb, 0x90, 0xa5, 0xad, 0x60, 0x3f, 0x78, 0xbe, 0x33, 0xd8, 0x71, 0xc8,
+	0x51, 0x4a, 0x5e, 0xc2, 0x3d, 0x27, 0x3a, 0x74, 0xaa, 0x43, 0x4e, 0x73, 0x6c, 0xdd, 0xb0, 0x44,
+	0xe2, 0x6a, 0xc7, 0x65, 0xa9, 0x4f, 0x73, 0x8c, 0x7e, 0x06, 0xf0, 0xb0, 0x4e, 0x4e, 0x66, 0xd3,
+	0x7f, 0x2e, 0x46, 0x3a, 0xd0, 0xcc, 0x18, 0x1f, 0x5f, 0x58, 0x9e, 0x96, 0x34, 0xc1, 0xd6, 0x96,
+	0x25, 0x37, 0x2c, 0xdc, 0xf7, 0x68, 0xf4, 0x2b, 0x80, 0x47, 0x8b, 0xae, 0x8e, 0xb8, 0x41, 0x75,
+	0x4a, 0x13, 0x5c, 0xe7, 0xec, 0x00, 0x1a, 0xcc, 0x73, 0xe7, 0x3d, 0xdd, 0xae, 0x50, 0x6b, 0x67,
+	0x59, 0x80, 0xad, 0xa5, 0xd3, 0xfa, 0x0c, 0xfb, 0x2b, 0x6c, 0x6d, 0x34, 0xb5, 0x0e, 0x34, 0x67,
+	0xde, 0x4e, 0xc5, 0x98, 0xa7, 0xd6, 0xdc, 0xf6, 0x60, 0x66, 0xf9, 0x6d, 0x81, 0x46, 0x3f, 0x02,
+	0x68, 0x79, 0xb1, 0xd7, 0xe9, 0x04, 0x95, 0x61, 0x1a, 0x37, 0xdc, 0x83, 0xf7, 0xb0, 0xeb, 0x93,
+	0xa1, 0x6b, 0x61, 0x55, 0x6e, 0xf5, 0xda, 0x5d, 0xbf, 0x6d, 0xfd, 0x4b, 0xf1, 0xbc, 0xd2, 0xa0,
+	0xe9, 0x0e, 0x7a, 0x20, 0xfa, 0x06, 0x0f, 0x6a, 0x6c, 0x6c, 0x90, 0x34, 0x84, 0x6d, 0x9a, 0x24,
+	0x28, 0x0d, 0xfa, 0x88, 0xd5, 0xef, 0x62, 0x0a, 0x34, 0xcd, 0x99, 0xd6, 0x4c, 0xf0, 0x21, 0x2a,
+	0x25, 0x94, 0xdf, 0x84, 0x0a, 0x3e, 0x2c, 0xd0, 0xe8, 0x7b, 0x00, 0xf7, 0x2b, 0x6f, 0x98, 0x8b,
+	0xc9, 0x75, 0x8c, 0x60, 0x0a, 0x77, 0xaf, 0x7a, 0xf8, 0x4f, 0xf9, 0x7b, 0x7f, 0x02, 0x20, 0x8b,
+	0x2b, 0x47, 0x46, 0xb0, 0xe7, 0xe6, 0x50, 0x53, 0x3c, 0xe8, 0xce, 0xbd, 0x54, 0x4b, 0xdf, 0x92,
+	0xf0, 0xe9, 0x3a, 0x5a, 0x91, 0xf1, 0x02, 0xda, 0xc7, 0xc8, 0xd3, 0x55, 0x97, 0xb1, 0xb3, 0xba,
+	0x4f, 0x45, 0x0c, 0x5f, 0x6c, 0x48, 0xb4, 0xca, 0xbd, 0xdf, 0x73, 0xc9, 0x3f, 0x48, 0x54, 0xb4,
+	0xe0, 0x68, 0xf2, 0x09, 0xee, 0x54, 0x6b, 0xe8, 0xcb, 0xe4, 0x59, 0x5d, 0xe7, 0xab, 0x97, 0x26,
+	0x8c, 0xd6, 0xb0, 0x8a, 0xbc, 0x1f, 0xa1, 0x51, 0xfe, 0xc5, 0x55, 0xef, 0x27, 0x75, 0xa7, 0x2e,
+	0xad, 0x62, 0xd8, 0x5e, 0x45, 0x91, 0xd9, 0xf4, 0xe4, 0xa6, 0x7d, 0xda, 0x5f, 0xfd, 0x0d, 0x00,
+	0x00, 0xff, 0xff, 0x62, 0x4e, 0x3f, 0xdf, 0x43, 0x06, 0x00, 0x00,
 }

--- a/pkg/nsm/apis/nseconnect/nseconnect.proto
+++ b/pkg/nsm/apis/nseconnect/nseconnect.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package nseconnect;
 
 import "github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh/netmesh.proto";
+import "github.com/ligato/networkservicemesh/pkg/nsm/apis/common/common.proto";
 
 // EndpointConnectionRequest is sent by a NSM to NSE to build a connection.
     message EndpointConnectionRequest {
@@ -20,22 +21,22 @@ import "github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh/netmesh.proto"
 
 // EndpointConnectionInterface is sent by a NSM to NSE to inform NSE about
 // the interface name which was created by the dataplane controller.
-    message EndpointConnectionInterface {
+    message EndpointConnectionMechanism {
         string request_id = 1;
-        string interface_name = 2;
+        common.LocalMechanism local_mechanism = 2;
         string network_service_name = 3;
     }
     
 // EndpointConnectionInterfaceReply is sent back by NSE to NSM to confirm the presence 
 // of the programmed interface.
-    message EndpointConnectionInterfaceReply {
+    message EndpointConnectionMechanismReply {
         string request_id = 1;
-        bool interface_found = 2;
+        bool mechanism_found = 2;
     }
 
     service EndpointConnection {
         rpc RequestEndpointConnection (EndpointConnectionRequest) returns (EndpointConnectionReply);
-        rpc SendEndpointConnectionInterface (EndpointConnectionInterface ) returns (EndpointConnectionInterfaceReply);
+        rpc SendEndpointConnectionMechanism (EndpointConnectionMechanism ) returns (EndpointConnectionMechanismReply);
     }
     
     message EndpointAdvertiseRequest {

--- a/pkg/nsm/apis/nseconnect/nseconnect.proto
+++ b/pkg/nsm/apis/nseconnect/nseconnect.proto
@@ -18,8 +18,24 @@ import "github.com/ligato/networkservicemesh/pkg/nsm/apis/netmesh/netmesh.proto"
         string linux_namespace = 3;
     }
 
+// EndpointConnectionInterface is sent by a NSM to NSE to inform NSE about
+// the interface name which was created by the dataplane controller.
+    message EndpointConnectionInterface {
+        string request_id = 1;
+        string interface_name = 2;
+        string network_service_name = 3;
+    }
+    
+// EndpointConnectionInterfaceReply is sent back by NSE to NSM to confirm the presence 
+// of the programmed interface.
+    message EndpointConnectionInterfaceReply {
+        string request_id = 1;
+        bool interface_found = 2;
+    }
+
     service EndpointConnection {
         rpc RequestEndpointConnection (EndpointConnectionRequest) returns (EndpointConnectionReply);
+        rpc SendEndpointConnectionInterface (EndpointConnectionInterface ) returns (EndpointConnectionInterfaceReply);
     }
     
     message EndpointAdvertiseRequest {

--- a/pkg/nsm/apis/nsmconnect/nsmconnect.pb.go
+++ b/pkg/nsm/apis/nsmconnect/nsmconnect.pb.go
@@ -29,10 +29,10 @@ type ConnectionRequest struct {
 	// Since connection request will trigger certain actions
 	// executed by NSM for a client to address idempotency, request_id
 	// will be tracked.
-	RequestId            string                   `protobuf:"bytes,1,opt,name=request_id,json=requestId" json:"request_id,omitempty"`
-	NetworkServiceName   string                   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName" json:"network_service_name,omitempty"`
-	LinuxNamespace       string                   `protobuf:"bytes,3,opt,name=linux_namespace,json=linuxNamespace" json:"linux_namespace,omitempty"`
-	LocalMechanisms      []*common.LocalMechanism `protobuf:"bytes,4,rep,name=local_mechanisms,json=localMechanisms" json:"local_mechanisms,omitempty"`
+	RequestId            string                   `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NetworkServiceName   string                   `protobuf:"bytes,2,opt,name=network_service_name,json=networkServiceName,proto3" json:"network_service_name,omitempty"`
+	LinuxNamespace       string                   `protobuf:"bytes,3,opt,name=linux_namespace,json=linuxNamespace,proto3" json:"linux_namespace,omitempty"`
+	LocalMechanisms      []*common.LocalMechanism `protobuf:"bytes,4,rep,name=local_mechanisms,json=localMechanisms,proto3" json:"local_mechanisms,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                 `json:"-"`
 	XXX_unrecognized     []byte                   `json:"-"`
 	XXX_sizecache        int32                    `json:"-"`
@@ -91,7 +91,7 @@ func (m *ConnectionRequest) GetLocalMechanisms() []*common.LocalMechanism {
 }
 
 type ConnectionParameters struct {
-	ConnectionParameters map[string]string `protobuf:"bytes,1,rep,name=connection_parameters,json=connectionParameters" json:"connection_parameters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ConnectionParameters map[string]string `protobuf:"bytes,1,rep,name=connection_parameters,json=connectionParameters,proto3" json:"connection_parameters,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -133,10 +133,10 @@ func (m *ConnectionParameters) GetConnectionParameters() map[string]string {
 // indicates that connection was refused and admission_error will provide details
 // why connection was refused.
 type ConnectionReply struct {
-	Accepted             bool                   `protobuf:"varint,1,opt,name=accepted" json:"accepted,omitempty"`
-	AdmissionError       string                 `protobuf:"bytes,2,opt,name=admission_error,json=admissionError" json:"admission_error,omitempty"`
-	ConnectionParameters *ConnectionParameters  `protobuf:"bytes,3,opt,name=connection_parameters,json=connectionParameters" json:"connection_parameters,omitempty"`
-	LocalMechanism       *common.LocalMechanism `protobuf:"bytes,4,opt,name=local_mechanism,json=localMechanism" json:"local_mechanism,omitempty"`
+	Accepted             bool                   `protobuf:"varint,1,opt,name=accepted,proto3" json:"accepted,omitempty"`
+	AdmissionError       string                 `protobuf:"bytes,2,opt,name=admission_error,json=admissionError,proto3" json:"admission_error,omitempty"`
+	ConnectionParameters *ConnectionParameters  `protobuf:"bytes,3,opt,name=connection_parameters,json=connectionParameters,proto3" json:"connection_parameters,omitempty"`
+	LocalMechanism       *common.LocalMechanism `protobuf:"bytes,4,opt,name=local_mechanism,json=localMechanism,proto3" json:"local_mechanism,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}               `json:"-"`
 	XXX_unrecognized     []byte                 `json:"-"`
 	XXX_sizecache        int32                  `json:"-"`
@@ -233,8 +233,7 @@ func (c *clientConnectionClient) RequestConnection(ctx context.Context, in *Conn
 	return out, nil
 }
 
-// Server API for ClientConnection service
-
+// ClientConnectionServer is the server API for ClientConnection service.
 type ClientConnectionServer interface {
 	RequestConnection(context.Context, *ConnectionRequest) (*ConnectionReply, error)
 }

--- a/pkg/nsm/apis/pod2nsm/api.pb.go
+++ b/pkg/nsm/apis/pod2nsm/api.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type DiscoverServiceRequest struct {
-	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -62,7 +62,7 @@ func (m *DiscoverServiceRequest) GetLabels() map[string]string {
 }
 
 type ServiceDiscoveryResponse struct {
-	ServiceIds           []string `protobuf:"bytes,1,rep,name=service_ids,json=serviceIds" json:"service_ids,omitempty"`
+	ServiceIds           []string `protobuf:"bytes,1,rep,name=service_ids,json=serviceIds,proto3" json:"service_ids,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -100,7 +100,7 @@ func (m *ServiceDiscoveryResponse) GetServiceIds() []string {
 }
 
 type PublishServiceRequest struct {
-	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -138,7 +138,7 @@ func (m *PublishServiceRequest) GetLabels() map[string]string {
 }
 
 type PublishServiceResponse struct {
-	ServiceId            string   `protobuf:"bytes,1,opt,name=service_id,json=serviceId" json:"service_id,omitempty"`
+	ServiceId            string   `protobuf:"bytes,1,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -176,7 +176,7 @@ func (m *PublishServiceResponse) GetServiceId() string {
 }
 
 type DelistServiceRequest struct {
-	ServiceId            string   `protobuf:"bytes,1,opt,name=service_id,json=serviceId" json:"service_id,omitempty"`
+	ServiceId            string   `protobuf:"bytes,1,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -244,7 +244,7 @@ func (m *DelistServiceResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_DelistServiceResponse proto.InternalMessageInfo
 
 type ExposeChannelRequest struct {
-	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -282,7 +282,7 @@ func (m *ExposeChannelRequest) GetLabels() map[string]string {
 }
 
 type ExposeChannelResponse struct {
-	ChannelId            string   `protobuf:"bytes,1,opt,name=channel_id,json=channelId" json:"channel_id,omitempty"`
+	ChannelId            string   `protobuf:"bytes,1,opt,name=channel_id,json=channelId,proto3" json:"channel_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -320,7 +320,7 @@ func (m *ExposeChannelResponse) GetChannelId() string {
 }
 
 type ConcealChannelRequest struct {
-	ChannelId            string   `protobuf:"bytes,1,opt,name=channel_id,json=channelId" json:"channel_id,omitempty"`
+	ChannelId            string   `protobuf:"bytes,1,opt,name=channel_id,json=channelId,proto3" json:"channel_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -388,7 +388,7 @@ func (m *ConcealChannelResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_ConcealChannelResponse proto.InternalMessageInfo
 
 type CreateConnectionRequest struct {
-	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels               map[string]string `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -426,7 +426,7 @@ func (m *CreateConnectionRequest) GetLabels() map[string]string {
 }
 
 type CreateConnectionResponse struct {
-	ConnectionId         string   `protobuf:"bytes,1,opt,name=connection_id,json=connectionId" json:"connection_id,omitempty"`
+	ConnectionId         string   `protobuf:"bytes,1,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -464,7 +464,7 @@ func (m *CreateConnectionResponse) GetConnectionId() string {
 }
 
 type DestroyConnectionRequest struct {
-	ConnectionId         string   `protobuf:"bytes,1,opt,name=connection_id,json=connectionId" json:"connection_id,omitempty"`
+	ConnectionId         string   `protobuf:"bytes,1,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -644,8 +644,7 @@ func (c *networkServicesClient) DestroyConnection(ctx context.Context, in *Destr
 	return out, nil
 }
 
-// Server API for NetworkServices service
-
+// NetworkServicesServer is the server API for NetworkServices service.
 type NetworkServicesServer interface {
 	DiscoverService(context.Context, *DiscoverServiceRequest) (*ServiceDiscoveryResponse, error)
 	PublishService(context.Context, *PublishServiceRequest) (*PublishServiceResponse, error)

--- a/pkg/nsm/apis/testdataplane/testdataplane.pb.go
+++ b/pkg/nsm/apis/testdataplane/testdataplane.pb.go
@@ -50,8 +50,8 @@ func (NSMPodType) EnumDescriptor() ([]byte, []int) {
 }
 
 type Metadata struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	Namespace            string   `protobuf:"bytes,2,opt,name=namespace" json:"namespace,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace            string   `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -96,8 +96,8 @@ func (m *Metadata) GetNamespace() string {
 }
 
 type Pod struct {
-	Metadata             *Metadata `protobuf:"bytes,1,opt,name=metadata" json:"metadata,omitempty"`
-	IpAddress            string    `protobuf:"bytes,2,opt,name=ip_address,json=ipAddress" json:"ip_address,omitempty"`
+	Metadata             *Metadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	IpAddress            string    `protobuf:"bytes,2,opt,name=ip_address,json=ipAddress,proto3" json:"ip_address,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -142,8 +142,8 @@ func (m *Pod) GetIpAddress() string {
 }
 
 type BuildConnectRequest struct {
-	SourcePod            *Pod     `protobuf:"bytes,1,opt,name=source_pod,json=sourcePod" json:"source_pod,omitempty"`
-	DestinationPod       *Pod     `protobuf:"bytes,2,opt,name=destination_pod,json=destinationPod" json:"destination_pod,omitempty"`
+	SourcePod            *Pod     `protobuf:"bytes,1,opt,name=source_pod,json=sourcePod,proto3" json:"source_pod,omitempty"`
+	DestinationPod       *Pod     `protobuf:"bytes,2,opt,name=destination_pod,json=destinationPod,proto3" json:"destination_pod,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -188,8 +188,8 @@ func (m *BuildConnectRequest) GetDestinationPod() *Pod {
 }
 
 type BuildConnectReply struct {
-	Built                bool     `protobuf:"varint,1,opt,name=built" json:"built,omitempty"`
-	BuildError           string   `protobuf:"bytes,2,opt,name=build_error,json=buildError" json:"build_error,omitempty"`
+	Built                bool     `protobuf:"varint,1,opt,name=built,proto3" json:"built,omitempty"`
+	BuildError           string   `protobuf:"bytes,2,opt,name=build_error,json=buildError,proto3" json:"build_error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -234,8 +234,8 @@ func (m *BuildConnectReply) GetBuildError() string {
 }
 
 type DeleteConnectRequest struct {
-	Pod                  *Pod       `protobuf:"bytes,1,opt,name=pod" json:"pod,omitempty"`
-	PodType              NSMPodType `protobuf:"varint,2,opt,name=pod_type,json=podType,enum=testdataplane.NSMPodType" json:"pod_type,omitempty"`
+	Pod                  *Pod       `protobuf:"bytes,1,opt,name=pod,proto3" json:"pod,omitempty"`
+	PodType              NSMPodType `protobuf:"varint,2,opt,name=pod_type,json=podType,proto3,enum=testdataplane.NSMPodType" json:"pod_type,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
 	XXX_unrecognized     []byte     `json:"-"`
 	XXX_sizecache        int32      `json:"-"`
@@ -280,8 +280,8 @@ func (m *DeleteConnectRequest) GetPodType() NSMPodType {
 }
 
 type DeleteConnectReply struct {
-	Deleted              bool     `protobuf:"varint,1,opt,name=deleted" json:"deleted,omitempty"`
-	DeleteError          string   `protobuf:"bytes,2,opt,name=delete_error,json=deleteError" json:"delete_error,omitempty"`
+	Deleted              bool     `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	DeleteError          string   `protobuf:"bytes,2,opt,name=delete_error,json=deleteError,proto3" json:"delete_error,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -367,8 +367,7 @@ func (c *buildConnectClient) RequestBuildConnect(ctx context.Context, in *BuildC
 	return out, nil
 }
 
-// Server API for BuildConnect service
-
+// BuildConnectServer is the server API for BuildConnect service.
 type BuildConnectServer interface {
 	RequestBuildConnect(context.Context, *BuildConnectRequest) (*BuildConnectReply, error)
 }
@@ -432,8 +431,7 @@ func (c *deleteConnectClient) RequestDeleteConnect(ctx context.Context, in *Dele
 	return out, nil
 }
 
-// Server API for DeleteConnect service
-
+// DeleteConnectServer is the server API for DeleteConnect service.
 type DeleteConnectServer interface {
 	RequestDeleteConnect(context.Context, *DeleteConnectRequest) (*DeleteConnectReply, error)
 }


### PR DESCRIPTION
Currently, there is no way to inform NSE about the interface name which the dataplane has programmed for the nsmclient/network service. This proto change adds a new message sent by NSM to  NSE with the interface name and corresponding network service. Based on this information NSE can start a listener or some other service routine on newly created interface.
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>