### PR TITLE
Add make verify to Circle CI sanity checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             sudo apt-get install yamllint python3-pkg-resources
             ./.circleci/install-shellcheck.sh
       - run: yamllint -c .yamllint.yml $(git ls-files '*.yaml' '*.yml' | grep -v 'vendor/')
-      - run: make check dep-check
+      - run: make check dep-check verify
 
   build:
     working_directory: /go/src/github.com/ligato/networkservicemesh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
             sudo apt-get install yamllint python3-pkg-resources
             ./.circleci/install-shellcheck.sh
       - run: yamllint -c .yamllint.yml $(git ls-files '*.yaml' '*.yml' | grep -v 'vendor/')
+      - run: go install ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
       - run: make check dep-check verify
 
   build:


### PR DESCRIPTION
Avoid build process going further to heavy cluster deploy phase in case of `make verify` failures