### PR TITLE
Make packet-destroy more stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,11 @@ jobs:
           command: kubectl create -f /cncf/rbac/
           environment:
             KUBECONFIG: /cncf/data/kubeconfig
-      - persist_to_workspace:
-          root: /cncf/data
+      - run: find /cncf/data
+      - save_cache:
+          key: cncf-data-{{.Environment.CIRCLE_WORKFLOW_ID}}
           paths:
-            - ./*
+            - data
 
   packet-integration-tests:
     working_directory: /go/src/github.com/ligato/networkservicemesh
@@ -63,15 +64,49 @@ jobs:
           command: |
             ./.circleci/set-nameserver.sh sudo
             sudo apt-get install gettext-base
-      - attach_workspace:
-          at: ./data
+      - run:
+          command: |
+            sudo mkdir -p /cncf/data
+            sudo chown -R circleci:circleci /cncf/
+          name: Cache Prep
+      - restore_cache:
+          key: cncf-data-{{.Environment.CIRCLE_WORKFLOW_ID}}
+      - run:
+          command: |
+            mv /cncf/data ./data
+            find ./data
+          name: Move Cache
       - run:
           command: ./scripts/circle-integration-tests.sh
           environment:
             KUBECONFIG: /go/src/github.com/ligato/networkservicemesh/data/kubeconfig
       - run:
-          when: always
-          command: ./.circleci/destroy-cluster.sh
+          when: on_fail
+          name: Trigger packet-destroy
+          command: |
+            curl --user ${CIRCLE_API_PROJECT_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=packet-destroy \
+                --data build_parameters[CIRCLE_WORKFLOW_ID]=${CIRCLE_WORKFLOW_ID} \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+
+
+  packet-destroy:
+    working_directory: /cncf
+    docker:
+      - image: registry.cncf.ci/cncf/cross-cloud/provisioning:production
+    steps:
+      - restore_cache:
+          key: cncf-data-{{.Environment.CIRCLE_WORKFLOW_ID}}
+      - run: find /cncf/data
+      - checkout:
+          path:
+            nsm
+      - run: nsm/.circleci/set-nameserver.sh
+      - run: nsm/.circleci/provision.sh packet-destroy
+      - run:
+          when: on_fail
+          command: nsm/.circleci/provision.sh packet-destroy
 
 workflows:
   version: 2
@@ -88,3 +123,6 @@ workflows:
           requires:
             - build
             - packet-deploy
+      - packet-destroy:
+          requires:
+            - packet-integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
           command: kubectl create -f /cncf/rbac/
           environment:
             KUBECONFIG: /cncf/data/kubeconfig
-      - run: find /cncf/data
       - save_cache:
           key: cncf-data-{{.Environment.CIRCLE_WORKFLOW_ID}}
           paths:
@@ -74,7 +73,6 @@ jobs:
       - run:
           command: |
             mv /cncf/data ./data
-            find ./data
           name: Move Cache
       - run:
           command: ./scripts/circle-integration-tests.sh
@@ -98,7 +96,6 @@ jobs:
     steps:
       - restore_cache:
           key: cncf-data-{{.Environment.CIRCLE_WORKFLOW_ID}}
-      - run: find /cncf/data
       - checkout:
           path:
             nsm


### PR DESCRIPTION
packet-destroy as part of the packet-integraion-tests job
was slow and unstable, due to issue with pulling
the provision docker image from the remote_docker
being very very slow (sometimes taking 30 minutes, or
timing out).

This same docker image, when used as the basis for a standalone
job (as is done for packet-deploy) is zippy and reliable.

This patch breaks packet-destroy out into a separate job.
In the event that integration-tests fails, it will use
the CircleCI API to launch the packet-destroy job.

This is done by storing the /cncf/data needed in a cache
with key cncf-data-{{.Environment.CIRCLE_WORKFLOW_ID}}
and having the API set CIRCLE_WORKFLOW_ID in the packet-destroy
job to match.

This has been tested and works.