### PR TITLE
Experiment: Mock k8s API and decouple NSM implementation

### DIFF
--- a/plugins/crd/crd_utils.go
+++ b/plugins/crd/crd_utils.go
@@ -73,7 +73,7 @@ func newCustomResourceDefinition(plugin *Plugin, FullName, Group, Version, Plura
 	return nil
 }
 
-func createCRDObject(newCRD *apiextv1beta1.CustomResourceDefinition, crdClient *apiextcs.Clientset) error {
+func createCRDObject(newCRD *apiextv1beta1.CustomResourceDefinition, crdClient apiextcs.Interface) error {
 	// First check if the CRD already exists
 	oldCRD, err := crdClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(newCRD.ObjectMeta.Name, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -123,7 +123,7 @@ func createCRDObject(newCRD *apiextv1beta1.CustomResourceDefinition, crdClient *
 // updateCRD attempts to update existing CRD with new definitions. number of attempts is defined in
 // nsmObjectUpdateRetries. In case of a conflict error code is returned, the update is re-attempted
 // as per optimistic concurrency approach.
-func updateCRD(newCRD *apiextv1beta1.CustomResourceDefinition, crdClient *apiextcs.Clientset) error {
+func updateCRD(newCRD *apiextv1beta1.CustomResourceDefinition, crdClient apiextcs.Interface) error {
 	for i := 0; i < nsmObjectUpdateRetries; i++ {
 		oldCRD, err := crdClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(newCRD.ObjectMeta.Name, metav1.GetOptions{})
 		if err != nil {

--- a/plugins/crd/plugin_impl_crd.go
+++ b/plugins/crd/plugin_impl_crd.go
@@ -23,13 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ligato/networkservicemesh/utils/helper/deptools"
-	"github.com/ligato/networkservicemesh/utils/helper/plugintools"
-	"github.com/ligato/networkservicemesh/utils/registry"
-
-	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/ligato/cn-infra/health/statuscheck"
 	"github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1"
 	client "github.com/ligato/networkservicemesh/pkg/client/clientset/versioned"
@@ -38,7 +31,12 @@ import (
 	"github.com/ligato/networkservicemesh/plugins/k8sclient"
 	"github.com/ligato/networkservicemesh/plugins/logger"
 	"github.com/ligato/networkservicemesh/plugins/objectstore"
+	"github.com/ligato/networkservicemesh/utils/helper/deptools"
+	"github.com/ligato/networkservicemesh/utils/helper/plugintools"
 	"github.com/ligato/networkservicemesh/utils/idempotent"
+	"github.com/ligato/networkservicemesh/utils/registry"
+	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -50,7 +48,7 @@ type Plugin struct {
 
 	pluginStopCh  chan struct{}
 	wg            sync.WaitGroup
-	apiclientset  *apiextcs.Clientset
+	apiclientset  apiextcs.Interface
 	crdClient     client.Interface
 	StatusMonitor statuscheck.StatusReader
 
@@ -152,10 +150,7 @@ func (plugin *Plugin) afterInit() error {
 	var err error
 
 	// Create clientset and create our CRD, this only needs to run once
-	plugin.apiclientset, err = apiextcs.NewForConfig(plugin.K8sclient.GetClientConfig())
-	if err != nil {
-		panic(err.Error())
-	}
+	plugin.apiclientset = plugin.K8sclient.GetAPIExtClientset()
 
 	// Create an instance of our own API client
 	plugin.crdClient = plugin.K8sclient.GetNSMClientset()

--- a/plugins/finalizer/finalizer_plugin.go
+++ b/plugins/finalizer/finalizer_plugin.go
@@ -67,7 +67,7 @@ type Plugin struct {
 	stopCh        chan struct{}
 	informer      cache.SharedIndexInformer
 	k8sClient     kubernetes.Interface
-	nsmClient     *nsmclient.Clientset
+	nsmClient     nsmclient.Interface
 	namespace     string
 }
 

--- a/plugins/finalizer/finalizer_plugin.go
+++ b/plugins/finalizer/finalizer_plugin.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/ligato/cn-infra/health/statuscheck"
+	nsmclient "github.com/ligato/networkservicemesh/pkg/client/clientset/versioned"
 	"github.com/ligato/networkservicemesh/plugins/k8sclient"
 	"github.com/ligato/networkservicemesh/plugins/logger"
 	"github.com/ligato/networkservicemesh/plugins/objectstore"
@@ -30,13 +31,11 @@ import (
 	"github.com/ligato/networkservicemesh/utils/registry"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
-
-	nsmclient "github.com/ligato/networkservicemesh/pkg/client/clientset/versioned"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (
@@ -67,7 +66,7 @@ type Plugin struct {
 	StatusMonitor statuscheck.StatusReader
 	stopCh        chan struct{}
 	informer      cache.SharedIndexInformer
-	k8sClient     *kubernetes.Clientset
+	k8sClient     kubernetes.Interface
 	nsmClient     *nsmclient.Clientset
 	namespace     string
 }

--- a/plugins/finalizer/finalizer_queue.go
+++ b/plugins/finalizer/finalizer_queue.go
@@ -132,7 +132,7 @@ func cleanUpNSMClient(plugin *Plugin, pod *v1.Pod) {
 	}
 }
 
-func checkForInUse(k8s *kubernetes.Clientset, pod *v1.Pod, podNamespace string) (bool, error) {
+func checkForInUse(k8s kubernetes.Interface, pod *v1.Pod, podNamespace string) (bool, error) {
 	var inUse bool
 	finalizers := pod.GetFinalizers()
 	nsmClients := []string{}

--- a/plugins/k8sclient/api.go
+++ b/plugins/k8sclient/api.go
@@ -24,7 +24,7 @@ import (
 // Interface is the interface to a k8sclient plugin
 type API interface {
 	GetClientConfig() *rest.Config
-	GetClientset() *kubernetes.Clientset
+	GetClientset() kubernetes.Interface
 	GetNSMClientset() *nsmclient.Clientset
 }
 

--- a/plugins/k8sclient/api.go
+++ b/plugins/k8sclient/api.go
@@ -17,15 +17,16 @@ package k8sclient
 import (
 	nsmclient "github.com/ligato/networkservicemesh/pkg/client/clientset/versioned"
 	"github.com/ligato/networkservicemesh/plugins/idempotent"
+	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 // Interface is the interface to a k8sclient plugin
 type API interface {
-	GetClientConfig() *rest.Config
+	//GetClientConfig() *rest.Config
 	GetClientset() kubernetes.Interface
-	GetNSMClientset() *nsmclient.Clientset
+	GetNSMClientset() nsmclient.Interface
+	GetAPIExtClientset() apiextcs.Interface
 }
 
 // PluginAPI for k8sclient

--- a/plugins/k8sclient/impl.go
+++ b/plugins/k8sclient/impl.go
@@ -17,16 +17,15 @@ package k8sclient
 import (
 	"fmt"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-
 	nsmclient "github.com/ligato/networkservicemesh/pkg/client/clientset/versioned"
 	"github.com/ligato/networkservicemesh/utils/command"
 	"github.com/ligato/networkservicemesh/utils/helper/deptools"
 	"github.com/ligato/networkservicemesh/utils/helper/plugintools"
 	"github.com/ligato/networkservicemesh/utils/idempotent"
 	"github.com/ligato/networkservicemesh/utils/registry"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Plugin for k8sclient
@@ -83,7 +82,7 @@ func (p *Plugin) GetClientConfig() *rest.Config {
 }
 
 // GetClientset returns a pointer to our kubernetes.Clientset object
-func (p *Plugin) GetClientset() *kubernetes.Clientset {
+func (p *Plugin) GetClientset() kubernetes.Interface {
 	return p.k8sClientset
 }
 

--- a/plugins/k8sclient/impl.go
+++ b/plugins/k8sclient/impl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ligato/networkservicemesh/utils/helper/plugintools"
 	"github.com/ligato/networkservicemesh/utils/idempotent"
 	"github.com/ligato/networkservicemesh/utils/registry"
+	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -34,8 +35,9 @@ type Plugin struct {
 	Deps
 
 	k8sClientConfig *rest.Config
-	k8sClientset    *kubernetes.Clientset
-	nsmClient       *nsmclient.Clientset
+	k8sClientset    kubernetes.Interface
+	nsmClient       nsmclient.Interface
+	apiclientset    apiextcs.Interface
 }
 
 // Init Plugin
@@ -58,9 +60,15 @@ func (p *Plugin) init() error {
 	if err != nil {
 		return fmt.Errorf("failed to build kubernetes client: %s", err)
 	}
+
 	p.nsmClient, err = nsmclient.NewForConfig(p.k8sClientConfig)
 	if err != nil {
 		return fmt.Errorf("failed to build networkservicemesh client: %s", err)
+	}
+
+	p.apiclientset, err = apiextcs.NewForConfig(p.k8sClientConfig)
+	if err != nil {
+		return fmt.Errorf("failed to build apiext client: %s", err)
 	}
 
 	return nil
@@ -87,6 +95,10 @@ func (p *Plugin) GetClientset() kubernetes.Interface {
 }
 
 // GetNSMClientset returns a pointer to our nsmClient.Clientset object
-func (p *Plugin) GetNSMClientset() *nsmclient.Clientset {
+func (p *Plugin) GetNSMClientset() nsmclient.Interface {
 	return p.nsmClient
+}
+
+func (p *Plugin) GetAPIExtClientset() apiextcs.Interface {
+	return p.apiclientset
 }

--- a/plugins/nsmserver/nsmserver_client.go
+++ b/plugins/nsmserver/nsmserver_client.go
@@ -29,8 +29,6 @@ import (
 	"sync"
 	"time"
 
-	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
-
 	nsmapi "github.com/ligato/networkservicemesh/pkg/apis/networkservicemesh.io/v1"
 	nsmclient "github.com/ligato/networkservicemesh/pkg/client/clientset/versioned"
 	dataplaneutils "github.com/ligato/networkservicemesh/pkg/dataplane/utils"
@@ -48,10 +46,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 )
 
 const (
@@ -67,7 +65,7 @@ type nsmClientEndpoints struct {
 	// Second key is NetworkService name
 	clientConnections map[string]map[string]*clientNetworkService
 	sync.RWMutex
-	k8sClient       *kubernetes.Clientset
+	k8sClient       kubernetes.Interface
 	nsmClient       *nsmclient.Clientset
 	namespace       string
 	nsmPodIPAddress string
@@ -92,7 +90,7 @@ type clientNetworkService struct {
 
 // getNetworkServiceEndpoint gets all advertised Endpoints for a specific Network Service
 func getNetworkServiceEndpoint(
-	k8sClient *kubernetes.Clientset,
+	k8sClient kubernetes.Interface,
 	nsmClient *nsmclient.Clientset,
 	networkService string,
 	namespace string) ([]nsmapi.NetworkServiceEndpoint, error) {
@@ -311,7 +309,7 @@ func localNSE(n *nsmClientEndpoints, requestID, networkServiceName string) error
 	return nil
 }
 
-func getPodNameByUID(k8s *kubernetes.Clientset, uid, namespace string) (string, error) {
+func getPodNameByUID(k8s kubernetes.Interface, uid, namespace string) (string, error) {
 	podList, err := k8s.CoreV1().Pods(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return "", err

--- a/plugins/nsmserver/nsmserver_client.go
+++ b/plugins/nsmserver/nsmserver_client.go
@@ -66,7 +66,7 @@ type nsmClientEndpoints struct {
 	clientConnections map[string]map[string]*clientNetworkService
 	sync.RWMutex
 	k8sClient       kubernetes.Interface
-	nsmClient       *nsmclient.Clientset
+	nsmClient       nsmclient.Interface
 	namespace       string
 	nsmPodIPAddress string
 }
@@ -91,7 +91,7 @@ type clientNetworkService struct {
 // getNetworkServiceEndpoint gets all advertised Endpoints for a specific Network Service
 func getNetworkServiceEndpoint(
 	k8sClient kubernetes.Interface,
-	nsmClient *nsmclient.Clientset,
+	nsmClient nsmclient.Interface,
 	networkService string,
 	namespace string) ([]nsmapi.NetworkServiceEndpoint, error) {
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{EndpointServiceLabel: networkService}))

--- a/plugins/nsmserver/nsmserver_endpoints.go
+++ b/plugins/nsmserver/nsmserver_endpoints.go
@@ -49,7 +49,7 @@ type nsmEndpointServer struct {
 	logger             logger.FieldLoggerPlugin
 	objectStore        objectstore.Interface
 	k8sClient          kubernetes.Interface
-	nsmClient          *nsmclient.Clientset
+	nsmClient          nsmclient.Interface
 	grpcServer         *grpc.Server
 	endPointSocketPath string
 	stopChannel        chan bool

--- a/plugins/nsmserver/nsmserver_endpoints.go
+++ b/plugins/nsmserver/nsmserver_endpoints.go
@@ -48,7 +48,7 @@ const (
 type nsmEndpointServer struct {
 	logger             logger.FieldLoggerPlugin
 	objectStore        objectstore.Interface
-	k8sClient          *kubernetes.Clientset
+	k8sClient          kubernetes.Interface
 	nsmClient          *nsmclient.Clientset
 	grpcServer         *grpc.Server
 	endPointSocketPath string


### PR DESCRIPTION
This is an experiment and probably not good idea, however, I want to try to mock k8s API which let to run NSM and components in an environment which simulate k8s cluster (at the level required by NSM components to function properly)...

## Why?
Potential benefits are (if the experiment succeed) :
 - increased development time: many parts can be executed and debugged on the local machine without docker and k8s 
 - simplified testing (both unit and integration): a huge amount of tests may be written without cluster set up; since this experiment is an attempt to decouple code in some form, decoupling leads to easier testing (both unit and integration)
 - because of decoupling, many functional components that require real environment (e.g. docker container) should be fine-grained, which leads to the more structured codebase and can be tested separately

## Risks
 - abstracting stuff may result in more work to maintain codebase and void benefits above
 - it would not be easy to reach experiment goal
 - I do not see a whole picture and this is a really bad idea :)

Anyway, I'd like to create this PR to use CI environment this weekend and see how this may progress