### PR TITLE
Add a cleanup step to build CircleCI Job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,24 @@ jobs:
             go install ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
             cd dataplanes/vpp ; make all ; cd -
             make verify docker-build docker-push
+      - run:
+          when: on_fail
+          name: Trigger packet-destroy
+          command: |
+            echo "Wait for 10 minutes to allow deploy to happen"
+            typeset -i numsec=600
+            typeset -i cnt=0
+            while [ $cnt -lt ${numsec} ]; do
+              echo -ne "Waited $cnt seconds out of $numsec\033[0K\r"
+              ((cnt=cnt+1))
+              sleep 1
+            done
+            curl --user ${CIRCLE_API_PROJECT_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=packet-destroy \
+                --data build_parameters[CIRCLE_WORKFLOW_ID]=${CIRCLE_WORKFLOW_ID} \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+
 
   packet-deploy:
     working_directory: /cncf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           name: Trigger packet-destroy
           command: |
             echo "Wait for 10 minutes to allow deploy to happen"
-            typeset -i numsec=600
+            typeset -i numsec=900
             typeset -i cnt=0
             while [ $cnt -lt ${numsec} ]; do
               echo -ne "Waited $cnt seconds out of $numsec\033[0K\r"


### PR DESCRIPTION
This is far from perfect, as it basically waits
10 minutes for packet-deploy to finish before triggering
packet-destroy.  I hate sleeps in tests... but its the best
we can do.

This has been tested:

1.  If the build is broken, cleanup happens correctly.
2.  If the build is broken *and* packet-deploy is broken,
    the packet-destroy triggered by the broken build
    does nothing, and reports success unless packet-deploy
    has completed.

So the only available mode in which this doesn't behave well is:

packet-deploy succeeds more than 10 minutes after the build breaks.
In that case we can leak servers.

The additional drawback is that build fails will take a bit longer to report.
