### PR TITLE
Break out log collection to obvious seperate step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,12 @@ jobs:
           environment:
             KUBECONFIG: /go/src/github.com/ligato/networkservicemesh/data/kubeconfig
       - run:
+          when: always
+          name: Dump Logs
+          command: ./scripts/dump_logs.sh
+          environment:
+            KUBECONFIG: /go/src/github.com/ligato/networkservicemesh/data/kubeconfig
+      - run:
           when: on_fail
           name: Trigger packet-destroy
           command: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ script:
   - cd dataplanes/vpp ; make all ; cd -
   - make all && ./scripts/travis-integration-tests.sh dind
 
+after_script:
+  - ./scripts/dump_logs.sh
+
 # We only want to push docker images on a push to master, not a pull request
 after_success:
   - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then export TAG=`if [ "${TRAVIS_BRANCH}" == "master" ]; then echo "latest"; else echo ${TRAVIS_BRANCH}; fi` && export BUILD_TAG=travis-"${TRAVIS_BUILD_NUMBER}" && make docker-push ; fi

--- a/scripts/circle-integration-tests.sh
+++ b/scripts/circle-integration-tests.sh
@@ -35,7 +35,6 @@ exit_code=$?
 if [ "${exit_code}" == "0" ] ; then
     echo "TESTS: PASS"
 else
-    error_collection
     echo "TESTS: FAIL"
 fi
 

--- a/scripts/dev-integration-tests.sh
+++ b/scripts/dev-integration-tests.sh
@@ -57,8 +57,8 @@ exit_code=$?
 if [ "${exit_code}" == "0" ] ; then
     echo "TESTS: PASS"
 else
-    error_collection
     echo "TESTS: FAIL"
+    echo "Run scripts/dump_logs.sh to dump logs for debugging"
 fi
 
 set +x

--- a/scripts/dump_logs.sh
+++ b/scripts/dump_logs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+. ./scripts/integration-test-helpers.sh
+dump_logs

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -140,7 +140,6 @@ function run_tests() {
     client_pod_namespace="$(kubectl get pods --all-namespaces | grep nsm-client | awk '{print $1}')"
     intf_number="$(kubectl exec "$client_pod_name" -n "$client_pod_namespace" -- ifconfig -a | grep -c nse)"
     if [ "$intf_number" -eq 0 ] ; then
-        error_collection
         return 1
     fi
     kubectl exec "$client_pod_name" -n "$client_pod_namespace" -- ping 1.1.1.2 -c 5

--- a/scripts/travis-integration-tests.sh
+++ b/scripts/travis-integration-tests.sh
@@ -54,7 +54,6 @@ exit_code=$?
 if [ "${exit_code}" == "0" ] ; then
     echo "TESTS: PASS"
 else
-    error_collection
     echo "TESTS: FAIL"
 fi
 


### PR DESCRIPTION
Right now, if we break, the 'point of breakage' ends up
being buried behind all the log collection.

The log collection is epic.  This patch breaks log collection out
into a separate script:

./scripts/dump_logs.sh

And puts it into separate steps into TravisCI and CircleCI that *always*
collect logs (error or not).