### PR TITLE
Make connection working with inode namespace parameters

### DIFF
--- a/dataplanes/vpp/pkg/nsmutils/nsm-utils.go
+++ b/dataplanes/vpp/pkg/nsmutils/nsm-utils.go
@@ -67,11 +67,7 @@ func ValidateParameters(parameters map[string]string, keyList Keys) error {
 }
 
 // Keys validator functions, for each new Keys there should be a validator function.
-func Namespace(value string) error {
-	// This is not true anymore
-	// if !strings.HasPrefix(value, "pid:") {
-	// 	return fmt.Errorf("malformed namespace %s, must start with \"pid:\" following by the process id of a container", value)
-	// }
+func Any(value string) error {
 	return nil
 }
 

--- a/dataplanes/vpp/pkg/nsmutils/nsm-utils.go
+++ b/dataplanes/vpp/pkg/nsmutils/nsm-utils.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 )
 
 const (
@@ -69,9 +68,10 @@ func ValidateParameters(parameters map[string]string, keyList Keys) error {
 
 // Keys validator functions, for each new Keys there should be a validator function.
 func Namespace(value string) error {
-	if !strings.HasPrefix(value, "pid:") {
-		return fmt.Errorf("malformed namespace %s, must start with \"pid:\" following by the process id of a container", value)
-	}
+	// This is not true anymore
+	// if !strings.HasPrefix(value, "pid:") {
+	// 	return fmt.Errorf("malformed namespace %s, must start with \"pid:\" following by the process id of a container", value)
+	// }
 	return nil
 }
 

--- a/dataplanes/vpp/pkg/nsmvpp/nsm_vpp_xconnect.go
+++ b/dataplanes/vpp/pkg/nsmvpp/nsm_vpp_xconnect.go
@@ -46,7 +46,7 @@ type KernelInterface struct{}
 var keyList = nsmutils.Keys{
 	nsmutils.NSMkeyNamespace: nsmutils.KeyProperties{
 		Mandatory: true,
-		Validator: nsmutils.Namespace},
+		Validator: nsmutils.Any},
 	nsmutils.NSMkeyIPv4: nsmutils.KeyProperties{
 		Mandatory: false,
 		Validator: nsmutils.Ipv4},

--- a/dataplanes/vpp/pkg/nsmvpp/nsm_vpp_xconnect.go
+++ b/dataplanes/vpp/pkg/nsmvpp/nsm_vpp_xconnect.go
@@ -15,6 +15,8 @@
 package nsmvpp
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -26,6 +28,7 @@ import (
 	"github.com/ligato/networkservicemesh/dataplanes/vpp/bin_api/tapv2"
 	"github.com/ligato/networkservicemesh/dataplanes/vpp/pkg/nsmutils"
 	"github.com/ligato/networkservicemesh/pkg/nsm/apis/common"
+	"github.com/ligato/networkservicemesh/utils/fs"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,7 +36,6 @@ type tapInterface struct {
 	id           uint32
 	name         string
 	namespace    []byte
-	pid          string
 	ip           []byte
 	prefixLength uint8
 	tag          []byte
@@ -53,6 +55,11 @@ var keyList = nsmutils.Keys{
 		Validator: nsmutils.Ipv4prefixlength},
 }
 
+func encode(s []byte) string {
+	md5 := md5.Sum(s)
+	return hex.EncodeToString(md5[:4])
+}
+
 // CreateLocalConnect creates two tap interfaces in corresponding namespaces and then cross connect them
 func (m KernelInterface) CreateLocalConnect(apiCh govppapi.Channel, srcParameters, dstParameters map[string]string) (string, error) {
 	var err error
@@ -67,18 +74,46 @@ func (m KernelInterface) CreateLocalConnect(apiCh govppapi.Channel, srcParameter
 	srcNamespace := srcParameters[nsmutils.NSMkeyNamespace]
 	dstNamespace := dstParameters[nsmutils.NSMkeyNamespace]
 
+	if !strings.HasPrefix(srcNamespace, "pid:") {
+		// assuming that inode of linux namespace has been passed
+		inode, err := strconv.ParseUint(srcNamespace, 10, 64)
+		if err != nil {
+			logrus.Errorf("can't parse integer: %s", srcNamespace)
+		} else {
+			srcNamespace, err = fs.FindFileInProc(inode, "/ns/net")
+			if err != nil {
+				logrus.Errorf("cant' find namespace for inode %d", inode)
+				return "", err
+			}
+		}
+	}
+
+	if !strings.HasPrefix(dstNamespace, "pid:") {
+		// assuming that inode of linux namespace has been passed
+		inode, err := strconv.ParseUint(dstNamespace, 10, 64)
+		if err != nil {
+			logrus.Errorf("can't parse integer: %s", dstNamespace)
+		} else {
+			dstNamespace, err = fs.FindFileInProc(inode, "/ns/net")
+			if err != nil {
+				logrus.Errorf("cant' find namespace for inode %d", inode)
+				return "", err
+			}
+		}
+	}
+
+	logrus.Infof("connecting namespaces %s and %s...", srcNamespace, dstNamespace)
+
 	tap1 := &tapInterface{
-		pid:       strings.Split(srcNamespace, ":")[1],
 		namespace: []byte(srcNamespace),
 		tag:       []byte("NSM_CLIENT"),
 	}
 	tap2 := &tapInterface{
-		pid:       strings.Split(dstNamespace, ":")[1],
 		namespace: []byte(dstNamespace),
 		tag:       []byte("NSM_CLIENT"),
 	}
-	tap1.name = "tap-" + tap1.pid + "-" + tap2.pid
-	tap2.name = "tap-" + tap2.pid + "-" + tap1.pid
+	tap1.name = "tap-" + encode(tap2.namespace)
+	tap2.name = "tap-" + encode(tap1.namespace)
 
 	// Making sure that total interface name length is not exceeding 15 bytes.
 	if len(tap1.name) > 15 {


### PR DESCRIPTION
Current vpp-daemon implementation accepts namespaces in form of pid:xxxx only. This change makes it working with inode values provided for namespaces.