### PR TITLE
Leaned out build of dataplanes/vpp containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,34 @@ jobs:
             export TAG="$BUILD_TAG"
             cd dataplanes/vpp
             make docker-build-memif-test docker-push-memif-test
+  build-vpplib:
+    working_directory: /go/src/github.com/ligato/networkservicemesh/
+    docker:
+      - image: circleci/golang:1.10
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          command: |
+            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="$BUILD_TAG"
+            cd dataplanes/vpp
+            make docker-build-vpplib docker-push-vpplib
+  build-govppbuilder:
+    working_directory: /go/src/github.com/ligato/networkservicemesh/
+    docker:
+      - image: circleci/golang:1.10
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          command: |
+            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="$BUILD_TAG"
+            cd dataplanes/vpp
+            make docker-build-govppbuilder docker-push-govppbuilder
 
 workflows:
   version: 2
@@ -221,6 +249,14 @@ workflows:
       - build-vpp:
           requires:
             - sanity-check
+      - build-vpplib:
+          requires:
+            - sanity-check
+            - build-govppbuilder
+      - build-govppbuilder:
+          requires:
+            - sanity-check
+            - build-vpp-daemon
       - build-vpp-daemon:
           requires:
             - sanity-check

--- a/dataplanes/vpp/Makefile
+++ b/dataplanes/vpp/Makefile
@@ -58,6 +58,8 @@ endif
 
 DOCKERBUILD=docker build ${HTTPBUILD} ${HTTPSBUILD}
 
+BUILD_CONTAINERS=vpp vpplib govppbuilder vpp-daemon memif-test
+
 .PHONY: all check verify docker-build docker-push
 #
 # The all target is what is used by the travis-ci system to build the Docker images
@@ -66,14 +68,13 @@ DOCKERBUILD=docker build ${HTTPBUILD} ${HTTPSBUILD}
 all: docker-build
 
 # Individual targets are found in .nsm.mk
-docker-build: docker-build-vpp-daemon docker-build-vpp docker-build-memif-test
-
-
-# Individual targets are found in .dataplane.mk
-docker-push: docker-login docker-push-vpp-daemon docker-push-vpp docker-build-memif-test
+docker-build:  $(addprefix docker-build-,$(BUILD_CONTAINERS))
 
 # Individual targets are found in .dataplane.mk
-docker-save: docker-save-vpp-daemon docker-save-vpp docker-build-memif-test
+docker-push: docker-login $(addprefix docker-build-,$(BUILD_CONTAINERS))
+
+# Individual targets are found in .dataplane.mk
+docker-save: $(addprefix docker-save-,$(BUILD_CONTAINERS))
 
 
 .PHONY: format deps generate install test test-race vet

--- a/dataplanes/vpp/build/Dockerfile.govppbuilder
+++ b/dataplanes/vpp/build/Dockerfile.govppbuilder
@@ -1,0 +1,12 @@
+FROM networkservicemesh/vpplib as govppbuilder
+ARG DEBIAN_FRONTEND=noninteractive
+ENV GOPATH="/root/go"
+RUN apt-get update && \
+    apt-get -y install golang axel git vpp-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists && \
+    mkdir -p $GOPATH/bin && \
+    mkdir -p $GOPATH/pkg && \
+    mkdir -p $GOPATH/src && \
+    axel -k https://raw.githubusercontent.com/golang/dep/master/install.sh && \
+    sh ./install.sh

--- a/dataplanes/vpp/build/Dockerfile.govppbuilder
+++ b/dataplanes/vpp/build/Dockerfile.govppbuilder
@@ -2,7 +2,7 @@ FROM networkservicemesh/vpplib as govppbuilder
 ARG DEBIAN_FRONTEND=noninteractive
 ENV GOPATH="/root/go"
 RUN apt-get update && \
-    apt-get -y install golang axel git vpp-dev && \
+    apt-get -y install golang axel git vpp-dev &&  \
     apt-get clean && \
     rm -rf /var/lib/apt/lists && \
     mkdir -p $GOPATH/bin && \

--- a/dataplanes/vpp/build/Dockerfile.vpp-daemon
+++ b/dataplanes/vpp/build/Dockerfile.vpp-daemon
@@ -1,29 +1,10 @@
-FROM ubuntu:bionic as vpplib
-ARG DEBIAN_FRONTEND=noninteractive
-ARG REPO=release
-RUN apt-get update
-RUN apt-get -y install curl
-RUN curl -s https://packagecloud.io/install/repositories/fdio/${REPO}/script.deb.sh |  bash
-RUN apt-get -y install vpp-lib=18.07.1-release
-RUN apt-get -y purge curl
-RUN apt-get -y clean
-
-FROM vpplib as govppbuilder
+FROM networkservicemesh/govppbuilder as govppbuilder
 ENV GOPATH="/root/go"
-RUN apt-get -y install golang curl git vpp-dev
-RUN mkdir -p $GOPATH/bin
-RUN mkdir -p $GOPATH/pkg
-RUN mkdir -p $GOPATH/src
-RUN curl -s https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-RUN mkdir -p $GOPATH/src/workspace/ligato/vpp
-ARG CACHE_DATE
 COPY .  $GOPATH/src/github.com/ligato/networkservicemesh
-ARG CACHE_DATE
 WORKDIR $GOPATH/src/github.com/ligato/networkservicemesh/dataplanes/vpp
-#RUN $GOPATH/bin/dep ensure
 RUN GOOS=linux go build  -a -o nsm-vpp-dataplane ./cmd/nsm-vpp-dataplane.go
 
-FROM  vpplib
+FROM  networkservicemesh/vpplib
 ENV GOPATH="/root/go"
 COPY --from=govppbuilder $GOPATH/src/github.com/ligato/networkservicemesh/dataplanes/vpp/nsm-vpp-dataplane /nsm-vpp-dataplane
 RUN chmod +x /nsm-vpp-dataplane

--- a/dataplanes/vpp/build/Dockerfile.vpplib
+++ b/dataplanes/vpp/build/Dockerfile.vpplib
@@ -1,0 +1,12 @@
+FROM ubuntu:bionic as vpplib
+ARG DEBIAN_FRONTEND=noninteractive
+ARG REPO=release
+RUN apt-get update && \
+    apt-get -y install axel && \
+    axel -k https://packagecloud.io/install/repositories/fdio/${REPO}/script.deb.sh && \
+    bash ./script.deb.sh && \
+    rm ./script.deb.sh && \
+    apt-get -y install vpp-lib=18.07.1-release && \
+    apt-get -y purge axel && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists


### PR DESCRIPTION
Turns out the bulk of dataplane/vpp containers
are builds that only need to be run with the Dockerfile changes.

vpp, vpplib, govppbuilder

Only require update with the Dockerfile changes.

So we only build them if they require update.