### PR TITLE
Vagrant: Install docker-ce 18.06

### DIFF
--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -19,10 +19,10 @@ Vagrant.configure("2") do |config|
   end
   config.vm.box = "bento/ubuntu-18.04"
   config.vm.network "private_network", type: "dhcp"
-   
-  # If you need hugepages, this is how you get them 
-  # config.vm.provision "shell", path: "scripts/setup_hugepages.sh"  
-  config.vm.provision "docker"
+
+  # If you need hugepages, this is how you get them
+  # config.vm.provision "shell", path: "scripts/setup_hugepages.sh"
+  config.vm.provision "shell", path: "scripts/install_docker.sh"
   config.vm.provision "shell", path: "scripts/install_kubernetes.sh"
   config.vm.provision "shell", path: "scripts/load_images.sh"
   config.vm.provision "shell", inline: "mkdir -p /var/lib/networkservicemesh"

--- a/scripts/vagrant/scripts/install_docker.sh
+++ b/scripts/vagrant/scripts/install_docker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Copy the vagrant docker provisioner, but force the docker version to 18.06
+# see:
+# - https://github.com/hashicorp/vagrant/blob/master/plugins/provisioners/docker/cap/debian/docker_install.rb
+
+apt-get update -qq -y
+apt-get install -qq -y --force-yes curl apt-transport-https
+apt-get purge -qq -y lxc-docker* || true
+curl -sSL https://get.docker.com/ | VERSION=18.06 sh


### PR DESCRIPTION
Ubuntu is now providing docker 18.09 by default.
Kubeadm reports an incompatibility error which prevent k8s
to be installed in the Vagrant VM.

Signed-off-by: Mathieu Rohon <mathieu.rohon@orange.com>