### PR TITLE
Add VPP Daemon debugging support

### DIFF
--- a/controlplane/Makefile
+++ b/controlplane/Makefile
@@ -34,7 +34,7 @@ GOVETTARGETS=cmd \
 ORG=networkservicemesh
 BUILD_CONTAINERS=nsmd
 RUN_CONTAINERS=dataplane $(BUILD_CONTAINERS)
-KILL_CONTAINERS=$(BUILD_CONTAINERS) vpp vpp-daemon
+KILL_CONTAINERS=$(BUILD_CONTAINERS)
 LOG_CONTAINERS=$(KILL_CONTAINERS)
 
 # Export some of the above variables so they persist for the shell scripts
@@ -79,7 +79,7 @@ docker-%-build:
 docker-debug-%: docker-build-debug docker-%-kill
 	@${DOCKERBUILD} -t networkservicemesh/$*-debug -f build/Dockerfile.$*-debug ..
 	@docker run -d --privileged -p 127.0.0.1:40000:40000 -v "/var/lib/networkservicemesh:/var/lib/networkservicemesh" networkservicemesh/$*-debug > /tmp/container.$*
-	@docker container ls | grep $$(cat /tmp/container.$*| cut -c1-12) > /dev/null && xargs docker logs < /tmp/container.$*
+	@docker container ls | grep $$(cat /tmp/container.$*| cut -c1-12) > /dev/null && xargs docker logs -f < /tmp/container.$*
 
 docker-build-debug: ../build/debug/Dockerfile.debug
 	@${DOCKERBUILD} -t networkservicemesh/debug -f ../build/debug/Dockerfile.debug ..

--- a/controlplane/docs/Debug.md
+++ b/controlplane/docs/Debug.md
@@ -16,7 +16,7 @@ Examples:
 * `make docker-debug-nsc` - debug of *controlplane/cmd/ncs*
 * `make docker-debug-nse` - debuf of *controlplane/cmd/nsmd*
 
-After docker image will be build and run, DLV will start it in listening mode on port 40000, so it will be required to forward a port using: 
+After docker image will be build and run, DLV will start it in listening mode on port 40000: 
 
 <pre>
 Successfully built xxxxxxx

--- a/dataplanes/vpp/.dataplane.mk
+++ b/dataplanes/vpp/.dataplane.mk
@@ -47,3 +47,7 @@ docker-push-%: docker-login
 docker-save-%:
 	mkdir -p ../../scripts/vagrant/images/; \
 	docker save -o ../../scripts/vagrant/images/$*.tar ${ORG}/$*
+
+.PHONY: docker-debug-%
+docker-debug-%:
+	@${DOCKERBUILD} -t ${ORG}/$*-debug -f build/Dockerfile.$*-debug ../../

--- a/dataplanes/vpp/Makefile
+++ b/dataplanes/vpp/Makefile
@@ -68,6 +68,21 @@ all: docker-build
 # Individual targets are found in .nsm.mk
 docker-build: docker-build-vpp-daemon docker-build-vpp docker-build-memif-test
 
+docker-debug: docker-debug-vpp-daemon docker-build-vpp
+
+docker-debug-run: docker-vpp-kill docker-vpp-daemon-kill
+	@echo "Starting vpp..."
+	@docker run --network=host --privileged=true --volume=/var/run:/var/run --volume=/var/lib:/var/lib --volume=/lib/modules:/lib/modules --ipc=host --pid=host -d networkservicemesh/vpp > /tmp/container.vpp
+	@echo "Starting vpp-daemon..."
+	@docker run --security-opt=seccomp:unconfined -p 40001:40000 --privileged=true --volume=/var/run:/var/run --volume=/var/lib:/var/lib --volume=/lib/modules:/lib/modules --volume=/var/lib/networkservicemesh:/var/lib/networkservicemesh/ --ipc=host --pid=host -d networkservicemesh/vpp-daemon-debug > /tmp/container.vpp-daemon
+	@docker container ls | grep $$(cat /tmp/container.vpp-daemon| cut -c1-12) > /dev/null && xargs docker logs -f < /tmp/container.vpp-daemon
+
+.PHONY: docker-%-kill
+docker-%-kill:
+	@echo "Killing $*..."
+	@docker container ls | grep $$(cat /tmp/container.$*| cut -c1-12) > /dev/null && xargs docker kill < /tmp/container.$* || echo "$* already killed"
+
+
 
 # Individual targets are found in .dataplane.mk
 docker-push: docker-login docker-push-vpp-daemon docker-push-vpp docker-build-memif-test

--- a/dataplanes/vpp/build/Dockerfile.vpp-daemon-debug
+++ b/dataplanes/vpp/build/Dockerfile.vpp-daemon-debug
@@ -1,0 +1,32 @@
+FROM ubuntu:bionic as vpplib
+ARG DEBIAN_FRONTEND=noninteractive
+ARG REPO=release
+RUN apt-get update
+RUN apt-get -y install curl
+RUN curl -s https://packagecloud.io/install/repositories/fdio/${REPO}/script.deb.sh |  bash
+RUN apt-get -y install vpp-lib=18.07.1-release
+RUN apt-get -y purge curl
+RUN apt-get -y clean
+
+# Install GO and dep
+ENV GOPATH="/root/go"
+RUN apt-get -y install golang curl git vpp-dev
+RUN mkdir -p $GOPATH/bin
+RUN mkdir -p $GOPATH/pkg
+RUN mkdir -p $GOPATH/src
+RUN curl -s https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+RUN mkdir -p $GOPATH/src/workspace/ligato/vpp
+
+# Compile Delve
+RUN echo "Building DLV"
+RUN go get github.com/derekparker/delve/cmd/dlv
+
+COPY .  $GOPATH/src/github.com/ligato/networkservicemesh
+WORKDIR $GOPATH/src/github.com/ligato/networkservicemesh/dataplanes/vpp
+
+#RUN $GOPATH/bin/dep ensure
+RUN GOOS=linux go build -i -gcflags "all=-N -l" -a -o nsm-vpp-dataplane ./cmd/nsm-vpp-dataplane.go
+RUN cp ./nsm-vpp-dataplane /nsm-vpp-dataplane
+RUN chmod +x /nsm-vpp-dataplane
+
+CMD ["/root/go/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/nsm-vpp-dataplane"]

--- a/dataplanes/vpp/docs/Debug.md
+++ b/dataplanes/vpp/docs/Debug.md
@@ -1,0 +1,44 @@
+A short guide to debug Go code inside Docker. 
+
+Debug is done using [Delve](http://github.com/derekparker/delve)
+
+## Build and Debug of vpp-dataplane-daemon compoment
+1. `docker-debug` - build a vpp docker image in release mode and vpp-daemon in debug mode.
+2. `make docker-debug-run` - run a vpp and vpp-daemon and forward debug port as 40001. 
+
+
+After docker image will be build and run, DLV will start it in listening mode on port 40001: 
+
+<pre>
+Successfully built xxxxxxx
+Successfully tagged networkservicemesh/nsc-debug:latest
+API server listening at: [::]:40000
+</pre>
+
+List of running images:
+<pre>
+# docker ps
+CONTAINER ID        IMAGE                                 COMMAND                  CREATED             STATUS              PORTS                        NAMES
+  4581ea17ff6e        networkservicemesh/vpp-daemon-debug   "/root/go/bin/dlv --…"   4 minutes ago       Up 4 minutes        0.0.0.0:40001->40000/tcp     vigilant_allen
+  805dac258d2c        networkservicemesh/vpp                "/usr/bin/vpp -c /et…"   4 minutes ago       Up 4 minutes                                     stoic_keldysh
+  735313bd644a        networkservicemesh/nsmd-debug         "/go/bin/dlv --liste…"   11 minutes ago      Up 11 minutes       127.0.0.1:40000->40000/tcp   xenodochial_jennings
+
+</pre>
+
+Since port is already forwarded we could attach via debugger.
+
+## IDEs
+
+Few IDEs are support Delve
+
+### Visual Studio Code
+TODO:
+
+### Goland IDE
+
+1. Go to menu: `Run -> Debug -> Edit configurations...` and add `Go Remote`.
+2. In dialog specify port `40001` as debug target and host `localhost` since we will forward a port.
+    ![Config img](./images/nsmesh_debug_config.png)
+3. Click debug and we ready.
+
+![Debug img](./images/nsmesh_under_debug.png)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -75,6 +75,14 @@ docker-build: $(addsuffix -build,$(addprefix docker-,$(BUILD_CONTAINERS)))
 docker-%-build:
 	@${DOCKERBUILD} -t networkservicemesh/$* -f build/Dockerfile.$* ..
 
+.PHONY: docker-debug-%
+docker-debug-%: docker-build-debug docker-%-kill
+	@${DOCKERBUILD} -t networkservicemesh/$*-debug -f build/Dockerfile.$*-debug ..
+	@docker run -d --privileged -p 127.0.0.1:40000:40000 -v "/var/lib/networkservicemesh:/var/lib/networkservicemesh" networkservicemesh/$*-debug > /tmp/container.$*
+	@docker container ls | grep $$(cat /tmp/container.$*| cut -c1-12) > /dev/null && xargs docker logs < /tmp/container.$*
+
+docker-build-debug: ../build/debug/Dockerfile.debug
+	@${DOCKERBUILD} -t networkservicemesh/debug -f ../build/debug/Dockerfile.debug ..
 
 docker-save: $(addsuffix -save,$(addprefix docker-,$(BUILD_CONTAINERS)))
 
@@ -93,7 +101,7 @@ docker-run: $(addsuffix -run,$(addprefix docker-,$(RUN_CONTAINERS)))
 .PHONY: docker-%-run
 docker-%-run: docker-%-build docker-%-kill
 	@echo "Starting $*..."
-	@docker run -d -v "/var/lib/networkservicemesh:/var/lib/networkservicemesh" $*/$* > /tmp/container.$*
+	@docker run -d --privileged=true -v "/var/lib/networkservicemesh:/var/lib/networkservicemesh" $*/$* > /tmp/container.$*
 
 .PHONY: docker-dataplane-run
 docker-dataplane-run:


### PR DESCRIPTION
Allow to do a NSMD from control plane and VPP Daemon debug.

Console-1
> cd controlplane
>  make docker-debug-nsmd
...
API server listening at: [::]:40000

Console-2
> cd dataplane/vpp
> make docker-debug
> make docker-debug-run  # will kill vpp and vpp-daemon from docker container and start them again.
Killing vpp...
805dac258d2c7737ed9253b218110a6bc5bb7e51f8ebba661165b587bab74fba
Killing vpp-daemon...
4581ea17ff6e1b1708bd0bb6372a00ebdee5e6b5505447d775bf95bb98967b97
Starting vpp...
Starting vpp-daemon...
API server listening at: [::]:40000

Debug will be forwarded to port 40001 on host machine.

So attaching to two of this components allow to do a proper debugging.


Signed-off-by: Andrey Sobolev <haiodo@gmail.com>