### PR TITLE
Configure vpp to not consume entire core

### DIFF
--- a/dataplane/vppagent/conf/vpp/startup.conf
+++ b/dataplane/vppagent/conf/vpp/startup.conf
@@ -5,6 +5,7 @@ unix {
   full-coredump
   cli-listen /run/vpp/cli.sock
   gid vpp
+  poll-sleep-usec 100
 }
 
 api-trace {


### PR DESCRIPTION
VPP by default will 'poll' continuously for traffic.
If you are in a high scalability/performance case this
is important and good.

If you are not it just becomes a process burning 100% of a CPU.

This config sets vpp up to poll-sleep, which radically reduces
CPU usage when not under heavy load, though with some costs
in the heavy load case.

For the average users, this setting is best.