### PR TITLE
Enable the VXLAN Mechanism in the vpp-dataplane (#342)

### DIFF
--- a/controlplane/pkg/apis/remote/connection/constants.go
+++ b/controlplane/pkg/apis/remote/connection/constants.go
@@ -2,7 +2,7 @@ package connection
 
 // Remote connection constants
 const (
-	VXLANSrcIP = "srcIp"
-	VXLANDstIP = "dstIp"
+	VXLANSrcIP = "src_ip"
+	VXLANDstIP = "dst_ip"
 	VXLANVNI   = "vni"
 )

--- a/controlplane/pkg/apis/remote/connection/constants.go
+++ b/controlplane/pkg/apis/remote/connection/constants.go
@@ -1,0 +1,8 @@
+package connection
+
+// Remote connection constants
+const (
+	VXLANSrcIP = "srcIp"
+	VXLANDstIP = "dstIp"
+	VXLANVNI   = "vni"
+)

--- a/controlplane/pkg/apis/remote/connection/helpers.go
+++ b/controlplane/pkg/apis/remote/connection/helpers.go
@@ -1,11 +1,134 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package connection
 
-func (*Connection) IsValid() error {
-	// TODO
+import (
+	fmt "fmt"
+	"net"
+	"strconv"
+)
+
+// IsValid - Did you tell me enough that some other party in the chain can fill in the blanks
+func (c *Connection) IsValid() error {
+	if c == nil {
+		return fmt.Errorf("Connection cannot be nil")
+	}
+	if c.GetNetworkService() == "" {
+		return fmt.Errorf("Connection.NetworkService cannot be empty: %v", c)
+	}
+
+	if c.GetMechanism() != nil {
+		if err := c.GetMechanism().isValid(); err != nil {
+			return fmt.Errorf("Invalid Mechanism in %v: %s", c, err)
+		}
+	}
 	return nil
 }
 
-func (*Connection) IsComplete() error {
-	// TODO
+// IsComplete - Have I been told enough to actually give you what you asked for
+func (c *Connection) IsComplete() error {
+	if err := c.IsValid(); err != nil {
+		return err
+	}
+
+	if c.GetId() == "" {
+		return fmt.Errorf("Connection.Id cannot be empty: %v", c)
+	}
+
+	if c.GetContext() == nil {
+		return fmt.Errorf("Connection.Context cannot be nil: %v", c)
+	}
+
 	return nil
+}
+
+func (m *Mechanism) isValid() error {
+	if m == nil {
+		return fmt.Errorf("Mechanism cannot be nil")
+	}
+	if m.GetParameters() == nil {
+		return fmt.Errorf("Mechanism.Parameters cannot be nil: %v", m)
+	}
+
+	if m.GetType() == MechanismType_VXLAN {
+		if _, err := m.SrcIP(); err != nil {
+			return fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for network namespace", m.GetType(), VXLANSrcIP)
+		}
+
+		if _, err := m.DstIP(); err != nil {
+			return fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for network namespace", m.GetType(), VXLANDstIP)
+		}
+
+		if _, err := m.VNI(); err != nil {
+			return fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for network namespace", m.GetType(), VXLANVNI)
+		}
+	}
+
+	return nil
+}
+
+// SrcIP returns the source IP parameter of the Mechanism
+func (m *Mechanism) SrcIP() (string, error) {
+	return m.getIPParameter(VXLANSrcIP)
+}
+
+// DstIP returns the destination IP parameter of the Mechanism
+func (m *Mechanism) DstIP() (string, error) {
+	return m.getIPParameter(VXLANDstIP)
+}
+
+func (m *Mechanism) getIPParameter(name string) (string, error) {
+	if m == nil {
+		return "", fmt.Errorf("Mechanism cannot be nil")
+	}
+	if m.GetParameters() == nil {
+		return "", fmt.Errorf("Mechanism.Parameters cannot be nil: %v", m)
+	}
+
+	ip, ok := m.Parameters[name]
+	if !ok {
+		return "", fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for network namespace", m.GetType(), name)
+	}
+
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return "", fmt.Errorf("Mechanism.Parameters[%s] must be a valid IPv4 or IPv6 address, instead was: %s: %v", name, ip, m)
+	}
+
+	return ip, nil
+}
+
+// VNI returns the VNI parameter of the Mechanism
+func (m *Mechanism) VNI() (uint32, error) {
+	if m == nil {
+		return 0, fmt.Errorf("Mechanism cannot be nil")
+	}
+	if m.GetParameters() == nil {
+		return 0, fmt.Errorf("Mechanism.Parameters cannot be nil: %v", m)
+	}
+
+	vxlanvni, ok := m.Parameters[VXLANVNI]
+	if !ok {
+		return 0, fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for network namespace", m.GetType(), VXLANVNI)
+	}
+
+	vni, err := strconv.ParseUint(vxlanvni, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("Mechanism.Parameters[%s] must be a valid IPv4 or IPv6 address, instead was: %s: %v", VXLANVNI, vxlanvni, m)
+	}
+
+	return uint32(vni), nil
 }

--- a/controlplane/pkg/apis/remote/connection/helpers.go
+++ b/controlplane/pkg/apis/remote/connection/helpers.go
@@ -65,15 +65,15 @@ func (m *Mechanism) isValid() error {
 
 	if m.GetType() == MechanismType_VXLAN {
 		if _, err := m.SrcIP(); err != nil {
-			return fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for network namespace", m.GetType(), VXLANSrcIP)
+			return fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for VXLAN tunnel", m.GetType(), VXLANSrcIP)
 		}
 
 		if _, err := m.DstIP(); err != nil {
-			return fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for network namespace", m.GetType(), VXLANDstIP)
+			return fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for VXLAN tunnel", m.GetType(), VXLANDstIP)
 		}
 
 		if _, err := m.VNI(); err != nil {
-			return fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for network namespace", m.GetType(), VXLANVNI)
+			return fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for VXLAN tunnel", m.GetType(), VXLANVNI)
 		}
 	}
 
@@ -100,7 +100,7 @@ func (m *Mechanism) getIPParameter(name string) (string, error) {
 
 	ip, ok := m.Parameters[name]
 	if !ok {
-		return "", fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for network namespace", m.GetType(), name)
+		return "", fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for the VXLAN tunnel", m.GetType(), name)
 	}
 
 	parsedIP := net.ParseIP(ip)
@@ -122,12 +122,13 @@ func (m *Mechanism) VNI() (uint32, error) {
 
 	vxlanvni, ok := m.Parameters[VXLANVNI]
 	if !ok {
-		return 0, fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s] for network namespace", m.GetType(), VXLANVNI)
+		return 0, fmt.Errorf("Mechanism.Type %s requires Mechanism.Parameters[%s]", m.GetType(), VXLANVNI)
 	}
 
-	vni, err := strconv.ParseUint(vxlanvni, 10, 64)
+	vni, err := strconv.ParseUint(vxlanvni, 10, 24)
+
 	if err != nil {
-		return 0, fmt.Errorf("Mechanism.Parameters[%s] must be a valid IPv4 or IPv6 address, instead was: %s: %v", VXLANVNI, vxlanvni, m)
+		return 0, fmt.Errorf("Mechanism.Parameters[%s] must be a valid 24-bit unsigned integer, instead was: %s: %v", VXLANVNI, vxlanvni, m)
 	}
 
 	return uint32(vni), nil

--- a/dataplane/vppagent/pkg/converter/remote_connection_converter.go
+++ b/dataplane/vppagent/pkg/converter/remote_connection_converter.go
@@ -1,24 +1,77 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package converter
 
 import (
-	remote "github.com/ligato/networkservicemesh/controlplane/pkg/apis/remote/connection"
+	fmt "fmt"
+	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/remote/connection"
+	"github.com/ligato/vpp-agent/plugins/vpp/model/interfaces"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
+	"github.com/sirupsen/logrus"
 )
 
+// RemoteConnectionConverter descibed the remote connection
 type RemoteConnectionConverter struct {
-	*remote.Connection
+	*connection.Connection
 	name string
 }
 
-func NewRemoteConnectionConverter(c *remote.Connection, name string) *RemoteConnectionConverter {
+// NewRemoteConnectionConverter creates a new remote connection coverter
+func NewRemoteConnectionConverter(c *connection.Connection, name string) *RemoteConnectionConverter {
 	return &RemoteConnectionConverter{
 		Connection: c,
 		name:       name,
 	}
 }
 
+// ToDataRequest handles the data request
 func (c *RemoteConnectionConverter) ToDataRequest(rv *rpc.DataRequest) (*rpc.DataRequest, error) {
-	// TODO
+	if c == nil {
+		return rv, fmt.Errorf("RemoteConnectionConverter cannot be nil")
+	}
+	if err := c.IsComplete(); err != nil {
+		return rv, err
+	}
+	if c.GetMechanism().GetType() != connection.MechanismType_VXLAN {
+		return rv, fmt.Errorf("RemoteConnectionConverter supports only VXLAN. Attempt to use Connection.Mechanism.Type %s", c.GetMechanism().GetType())
+	}
+	if rv == nil {
+		rv = &rpc.DataRequest{}
+	}
+
+	m := c.GetMechanism()
+
+	srcip, _ := m.SrcIP()
+	dstip, _ := m.DstIP()
+	vni, _ := m.VNI()
+
+	logrus.Infof("m.GetParameters()[%s]: %s", connection.VXLANSrcIP, srcip)
+	logrus.Infof("m.GetParameters()[%s]: %s", connection.VXLANDstIP, dstip)
+	logrus.Infof("m.GetParameters()[%s]: %d", connection.VXLANVNI, vni)
+
+	rv.Interfaces = append(rv.Interfaces, &interfaces.Interfaces_Interface{
+		Name:    c.name,
+		Type:    interfaces.InterfaceType_VXLAN_TUNNEL,
+		Enabled: true,
+		Vxlan: &interfaces.Interfaces_Interface_Vxlan{
+			SrcAddress: srcip,
+			DstAddress: dstip,
+			Vni:        vni,
+		},
+	})
 
 	return rv, nil
 }

--- a/dataplane/vppagent/pkg/vppagent/vppagent.go
+++ b/dataplane/vppagent/pkg/vppagent/vppagent.go
@@ -62,11 +62,16 @@ func NewVPPAgent(vppAgentEndpoint string, monitor monitor_crossconnect_server.Mo
 		monitor:          monitor,
 		mechanisms: &Mechanisms{
 			localMechanisms: []*local.Mechanism{
-				&local.Mechanism{
+				{
 					Type: local.MechanismType_KERNEL_INTERFACE,
 				},
-				&local.Mechanism{
+				{
 					Type: local.MechanismType_MEM_INTERFACE,
+				},
+			},
+			remoteMechanisms: []*remote.Mechanism{
+				{
+					Type: remote.MechanismType_VXLAN,
 				},
 			},
 		},


### PR DESCRIPTION
The remote VXLAN enablement was modelled based on the Kernel interface implementation form the local mechanism.
Tests are still TBD.

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>