### PR TITLE
nsmd begins listening for incoming calls after data plane registers

### DIFF
--- a/controlplane/pkg/nsmd/nsmd.go
+++ b/controlplane/pkg/nsmd/nsmd.go
@@ -103,18 +103,11 @@ func (nsm *nsmServer) DeleteClientConnection(context context.Context, request *n
 
 func waitForDataplaneAvailable(model model.Model) {
 	logrus.Info("Waiting for dataplane available...")
-	ticker := time.NewTicker(100 * time.Millisecond)
-	available := make(chan bool)
-	go func() {
-		for _ = range ticker.C {
-			dp, _ := model.SelectDataplane()
-			if dp != nil {
-				available <- true
-				ticker.Stop()
-			}
+	for ; true; <-time.After(100 * time.Millisecond) {
+		if dp, _ := model.SelectDataplane(); dp != nil {
+			break
 		}
-	}()
-	<-available
+	}
 }
 
 func StartNSMServer(model model.Model) error {


### PR DESCRIPTION
This change enforce a proper order of events as described in #493

The proper order of events is:
1. Dataplane registers with nsmd
1. nsmd begins listening for incoming NSMD.RequestClientConnection(..) calls

This can be easily rectified in StartNSMServer by looping over a call to model.SelectDataplane() until it returns a non-nil value.