### PR TITLE
nsmpd waits for nsmd to be available

### DIFF
--- a/k8s/cmd/nsmdp/nsmdp.go
+++ b/k8s/cmd/nsmdp/nsmdp.go
@@ -149,8 +149,17 @@ func startDeviceServer(nsm *nsmClientEndpoints) error {
 	return nil
 }
 
+func waitForNsmdAvailable() {
+	for {
+		if tools.WaitForPortAvailable(context.Background(), "unix", nsmd.ServerSock, 100*time.Millisecond) == nil {
+			break
+		}
+	}
+}
+
 // NewNSMDeviceServer registers and starts Kubelet's device plugin
 func NewNSMDeviceServer() error {
+	waitForNsmdAvailable()
 	nsm := &nsmClientEndpoints{}
 	if err := startDeviceServer(nsm); err != nil {
 		return err


### PR DESCRIPTION
This is best accomplished by inserting into NewNSMDeviceServer a call to WaitForPortAvailable to Wait until nsmd is responding before proceeding.

See #493 