### PR TITLE
controlplane: implement a simple Ednpoint selection. Implements 534

### DIFF
--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -203,7 +203,7 @@ func NewModel() Model {
 		networkServices: make(map[string][]*registry.NSERegistration),
 		endpoints:       make(map[string]*registry.NSERegistration),
 		listeners:       []ModelListener{},
-		selector:        selector.NewRoundRobinSelector(),
+		selector:        selector.NewMatchSelector(),
 		lastVNI:         1,
 	}
 }

--- a/controlplane/pkg/nsmd/network_service_server.go
+++ b/controlplane/pkg/nsmd/network_service_server.go
@@ -41,7 +41,7 @@ func NewNetworkServiceServer(model model.Model, workspace *Workspace, serviceReg
 	}
 }
 
-func (srv *networkServiceServer) getEndpointFromRegistry(ctx context.Context, networkServiceName string, networkServiceLabels map[string]string) *registry.NSERegistration {
+func (srv *networkServiceServer) getEndpointFromRegistry(ctx context.Context, requestConnection *connection.Connection) *registry.NSERegistration {
 	// Get endpoints
 	discoveryClient, err := srv.serviceRegistry.NetworkServiceDiscovery()
 	if err != nil {
@@ -49,14 +49,14 @@ func (srv *networkServiceServer) getEndpointFromRegistry(ctx context.Context, ne
 		return nil
 	}
 	nseRequest := &registry.FindNetworkServiceRequest{
-		NetworkServiceName: networkServiceName,
+		NetworkServiceName: requestConnection.GetNetworkService(),
 	}
 	endpointResponse, err := discoveryClient.FindNetworkService(ctx, nseRequest)
 	if err != nil {
 		logrus.Error(err)
 		return nil
 	}
-	endpoint := srv.model.GetSelector().SelectEndpoint(endpointResponse.GetNetworkService(), networkServiceLabels, endpointResponse.GetNetworkServiceEndpoints())
+	endpoint := srv.model.GetSelector().SelectEndpoint(requestConnection, endpointResponse.GetNetworkService(), endpointResponse.GetNetworkServiceEndpoints())
 	if endpoint == nil {
 		return nil
 	}
@@ -97,7 +97,7 @@ func (srv *networkServiceServer) Request(ctx context.Context, request *networkse
 		defer dataplaneConn.Close()
 	}
 
-	endpoint := srv.getEndpointFromRegistry(ctx, request.GetConnection().GetNetworkService(), request.GetConnection().GetLabels())
+	endpoint := srv.getEndpointFromRegistry(ctx, request.GetConnection())
 	if err != nil {
 		return nil, err
 	}

--- a/controlplane/pkg/nsmd/network_service_server.go
+++ b/controlplane/pkg/nsmd/network_service_server.go
@@ -41,7 +41,7 @@ func NewNetworkServiceServer(model model.Model, workspace *Workspace, serviceReg
 	}
 }
 
-func (srv *networkServiceServer) getEndpointFromRegistry(ctx context.Context, networkServiceName string) *registry.NSERegistration {
+func (srv *networkServiceServer) getEndpointFromRegistry(ctx context.Context, networkServiceName string, networkServiceLabels map[string]string) *registry.NSERegistration {
 	// Get endpoints
 	discoveryClient, err := srv.serviceRegistry.NetworkServiceDiscovery()
 	if err != nil {
@@ -56,7 +56,7 @@ func (srv *networkServiceServer) getEndpointFromRegistry(ctx context.Context, ne
 		logrus.Error(err)
 		return nil
 	}
-	endpoint := srv.model.GetSelector().SelectEndpoint(endpointResponse.GetNetworkService(), endpointResponse.GetNetworkServiceEndpoints())
+	endpoint := srv.model.GetSelector().SelectEndpoint(endpointResponse.GetNetworkService(), networkServiceLabels, endpointResponse.GetNetworkServiceEndpoints())
 	if endpoint == nil {
 		return nil
 	}
@@ -97,7 +97,7 @@ func (srv *networkServiceServer) Request(ctx context.Context, request *networkse
 		defer dataplaneConn.Close()
 	}
 
-	endpoint := srv.getEndpointFromRegistry(ctx, request.GetConnection().GetNetworkService())
+	endpoint := srv.getEndpointFromRegistry(ctx, request.GetConnection().GetNetworkService(), request.GetConnection().GetLabels())
 	if err != nil {
 		return nil, err
 	}

--- a/controlplane/pkg/selector/match_selector.go
+++ b/controlplane/pkg/selector/match_selector.go
@@ -1,0 +1,82 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selector
+
+import (
+	"sync"
+
+	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/registry"
+)
+
+type matchSelector struct {
+	sync.Mutex
+	roundRobin Selector
+}
+
+// NewMatchSelector creates a new
+func NewMatchSelector() Selector {
+	return &matchSelector{
+		roundRobin: NewRoundRobinSelector(),
+	}
+}
+
+// isSubset checks if B is a subset of A. TODO: reconsider this as a part of "tools"
+func isSubset(A, B map[string]string) bool {
+	if len(A) < len(B) {
+		return false
+	}
+	for k, v := range B {
+		if A[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *matchSelector) matchEndpoint(ns *registry.NetworkService, nsLabels map[string]string, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
+	//Iterate through the matches
+	for _, match := range ns.GetMatches() {
+		// All match source selector labels should be present in the requested labels map
+		if !isSubset(nsLabels, match.GetSourceSelector()) {
+			break
+		}
+
+		nseCandidates := []*registry.NetworkServiceEndpoint{}
+		// Check all Destinations in that match
+		for _, destination := range match.GetRoutes() {
+			// Each NSE should be matched against that destination
+			for _, nse := range networkServiceEndpoints {
+				if isSubset(nse.GetLabels(), destination.GetDestinationSelector()) {
+					nseCandidates = append(nseCandidates, nse)
+				}
+			}
+		}
+
+		if len(nseCandidates) > 0 {
+			// We found candidates. Use RoundRobin to select one
+			return m.roundRobin.SelectEndpoint(ns, nil, nseCandidates)
+		}
+	}
+	return nil
+}
+
+func (m *matchSelector) SelectEndpoint(ns *registry.NetworkService, nsLabels map[string]string, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
+	if len(ns.GetMatches()) == 0 {
+		return m.roundRobin.SelectEndpoint(ns, nil, networkServiceEndpoints)
+	}
+
+	return m.matchEndpoint(ns, nsLabels, networkServiceEndpoints)
+}

--- a/controlplane/pkg/selector/match_selector.go
+++ b/controlplane/pkg/selector/match_selector.go
@@ -18,6 +18,7 @@ package selector
 import (
 	"sync"
 
+	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/registry"
 )
 
@@ -46,7 +47,7 @@ func isSubset(A, B map[string]string) bool {
 	return true
 }
 
-func (m *matchSelector) matchEndpoint(ns *registry.NetworkService, nsLabels map[string]string, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
+func (m *matchSelector) matchEndpoint(nsLabels map[string]string, ns *registry.NetworkService, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
 	//Iterate through the matches
 	for _, match := range ns.GetMatches() {
 		// All match source selector labels should be present in the requested labels map
@@ -67,16 +68,16 @@ func (m *matchSelector) matchEndpoint(ns *registry.NetworkService, nsLabels map[
 
 		if len(nseCandidates) > 0 {
 			// We found candidates. Use RoundRobin to select one
-			return m.roundRobin.SelectEndpoint(ns, nil, nseCandidates)
+			return m.roundRobin.SelectEndpoint(nil, ns, nseCandidates)
 		}
 	}
 	return nil
 }
 
-func (m *matchSelector) SelectEndpoint(ns *registry.NetworkService, nsLabels map[string]string, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
+func (m *matchSelector) SelectEndpoint(requestConnection *connection.Connection, ns *registry.NetworkService, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
 	if len(ns.GetMatches()) == 0 {
-		return m.roundRobin.SelectEndpoint(ns, nil, networkServiceEndpoints)
+		return m.roundRobin.SelectEndpoint(nil, ns, networkServiceEndpoints)
 	}
 
-	return m.matchEndpoint(ns, nsLabels, networkServiceEndpoints)
+	return m.matchEndpoint(requestConnection.GetLabels(), ns, networkServiceEndpoints)
 }

--- a/controlplane/pkg/selector/round_robin_selector.go
+++ b/controlplane/pkg/selector/round_robin_selector.go
@@ -17,7 +17,7 @@ func NewRoundRobinSelector() Selector {
 	}
 }
 
-func (rr *roundRobinSelector) SelectEndpoint(ns *registry.NetworkService, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
+func (rr *roundRobinSelector) SelectEndpoint(ns *registry.NetworkService, nsLabels map[string]string, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
 	if rr == nil {
 		return nil
 	}

--- a/controlplane/pkg/selector/round_robin_selector.go
+++ b/controlplane/pkg/selector/round_robin_selector.go
@@ -3,6 +3,7 @@ package selector
 import (
 	"sync"
 
+	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/registry"
 )
 
@@ -17,7 +18,7 @@ func NewRoundRobinSelector() Selector {
 	}
 }
 
-func (rr *roundRobinSelector) SelectEndpoint(ns *registry.NetworkService, nsLabels map[string]string, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
+func (rr *roundRobinSelector) SelectEndpoint(requestConnection *connection.Connection, ns *registry.NetworkService, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
 	if rr == nil {
 		return nil
 	}

--- a/controlplane/pkg/selector/selector.go
+++ b/controlplane/pkg/selector/selector.go
@@ -3,5 +3,5 @@ package selector
 import "github.com/ligato/networkservicemesh/controlplane/pkg/apis/registry"
 
 type Selector interface {
-	SelectEndpoint(ns *registry.NetworkService, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint
+	SelectEndpoint(ns *registry.NetworkService, nsLabels map[string]string, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint
 }

--- a/controlplane/pkg/selector/selector.go
+++ b/controlplane/pkg/selector/selector.go
@@ -1,7 +1,10 @@
 package selector
 
-import "github.com/ligato/networkservicemesh/controlplane/pkg/apis/registry"
+import (
+	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/local/connection"
+	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/registry"
+)
 
 type Selector interface {
-	SelectEndpoint(ns *registry.NetworkService, nsLabels map[string]string, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint
+	SelectEndpoint(requestConnection *connection.Connection, ns *registry.NetworkService, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint
 }


### PR DESCRIPTION
This implements an exact match when requesting a NSE selection.

Based on PR https://github.com/ligato/networkservicemesh/pull/537