### PR TITLE
CrossConnect monitor tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,12 @@ jobs:
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
       - run:
+          when: always
+          name: Dump CrossConnect Monitor logs
+          command: make k8s-crossconnect-monitor-logs
+          environment:
+            KUBECONFIG: /home/circleci/project/data/kubeconfig
+      - run:
           when: on_fail
           name: Trigger packet-destroy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,20 @@ jobs:
             export TAG="$BUILD_TAG"
             make docker-nsmdp-build
             make docker-nsmdp-push
+  build-crossconnect-monitor:
+    working_directory: /go/src/github.com/ligato/networkservicemesh/
+    docker:
+      - image: circleci/golang:1.10
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          command: |
+            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="$BUILD_TAG"
+            make docker-crossconnect-monitor-build
+            make docker-crossconnect-monitor-push
   build-icmp-responder-nse:
     working_directory: /go/src/github.com/ligato/networkservicemesh/
     docker:
@@ -287,6 +301,9 @@ workflows:
       - build-nsmd-k8s:
           requires:
             - sanity-check
+      - build-crossconnect-monitor:
+          requires:
+            - sanity-check
       - build-nsmdp:
           requires:
             - sanity-check
@@ -310,6 +327,7 @@ workflows:
             - build-nsmd
             - build-nsmd-k8s
             - build-nsmdp
+            - build-crossconnect-monitor
             - build-icmp-responder-nse
             - build-vppagent-icmp-responder-nse
             - build-nsc

--- a/.docker.mk
+++ b/.docker.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUILD_CONTAINERS=nsc nsmd nsmdp nsmd-k8s icmp-responder-nse vppagent-dataplane devenv
+BUILD_CONTAINERS=nsc nsmd nsmdp nsmd-k8s icmp-responder-nse vppagent-dataplane devenv crossconnect-monitor
 RUN_CONTAINERS=$(BUILD_CONTAINERS)
 KILL_CONTAINERS=$(BUILD_CONTAINERS)
 LOG_CONTAINERS=$(KILL_CONTAINERS)

--- a/.k8s.mk
+++ b/.k8s.mk
@@ -15,7 +15,7 @@
 K8S_CONF_DIR = k8s/conf/
 
 # Need nsmdp and icmp-responder-nse here as well, but missing yaml files
-DEPLOYS = nsmd vppagent-dataplane vppagent-icmp-responder-nse icmp-responder-nse nsc
+DEPLOYS = nsmd vppagent-dataplane vppagent-icmp-responder-nse icmp-responder-nse nsc crossconnect-monitor
 
 CLUSTER_CONFIGS = cluster-role-admin cluster-role-binding cluster-role-view
 
@@ -185,6 +185,7 @@ k8s-nsmd-logs:
 
 .PHONY: k8s-%-debug
 k8s-%-debug:
+	@echo "Debugging $*"
 	@kubectl exec -ti $$(kubectl get pods | grep $*- | cut -d \  -f1) /go/src/github.com/ligato/networkservicemesh/scripts/debug.sh $*
 
 .PHONY: k8s-nsmd-debug
@@ -193,8 +194,8 @@ k8s-nsmd-debug:
 
 .PHONY: k8s-forward
 k8s-forward:
-	@echo "Forwarding remote 40000 to $(port) for $(pod)"
-	@kubectl port-forward $$(kubectl get pods | grep $(pod) | cut -d \  -f1) $(port):40000
+	@echo "Forwarding local $(port1) to $(port2) for $(pod)"
+	@kubectl port-forward $$(kubectl get pods | grep $(pod) | cut -d \  -f1) $(port1):$(port2)
 
 .PHONY: k8s-check
 k8s-check:

--- a/controlplane/pkg/tests/mode_test.go
+++ b/controlplane/pkg/tests/mode_test.go
@@ -186,3 +186,30 @@ func TestModelListenEndpoint(t *testing.T) {
 
 	model.RemoveListener(listener)
 }
+
+func TestModelListenExistingEndpoint(t *testing.T) {
+	RegisterTestingT(t)
+
+	model := newModel()
+	listener := &ListenerImpl{}
+
+	model.AddEndpoint(&registry.NSERegistration{
+		NetworkserviceEndpoint: &registry.NetworkServiceEndpoint{
+			NetworkServiceName: "golden-network",
+			EndpointName:       "ep1",
+		},
+	})
+
+	// Since model will call for all existing, this should be same
+	model.AddListener(listener)
+
+	Expect(listener.dataplanes).To(Equal(0))
+	Expect(listener.endpoints).To(Equal(1))
+
+	model.DeleteEndpoint("ep1")
+
+	Expect(listener.dataplanes).To(Equal(0))
+	Expect(listener.endpoints).To(Equal(0))
+
+	model.RemoveListener(listener)
+}

--- a/docker/Dockerfile.crossconnect-monitor
+++ b/docker/Dockerfile.crossconnect-monitor
@@ -1,0 +1,8 @@
+FROM golang:alpine as build
+ENV PACKAGEPATH=github.com/ligato/networkservicemesh/
+COPY [".","/go/src/${PACKAGEPATH}"]
+WORKDIR /go/src/${PACKAGEPATH}/
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/crossconnect-monitor ./k8s/cmd/crossconnect-monitor
+FROM alpine as runtime
+COPY --from=build /go/bin/crossconnect-monitor /bin/crossconnect-monitor
+ENTRYPOINT ["/bin/crossconnect-monitor"]

--- a/k8s/cmd/crossconnect-monitor/crossconnect_monitor.go
+++ b/k8s/cmd/crossconnect-monitor/crossconnect_monitor.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/crossconnect"
+	"github.com/ligato/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var closing = false
+var managers = map[string]string{}
+
+func monitorCrossConnects(address string, continuousMonitor bool) {
+	var err error
+	logrus.Infof("Starting CrossConnections Monitor on %s", address)
+	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	if err != nil {
+		logrus.Errorf("failure to communicate with the socket %s with error: %+v", address, err)
+		return
+	}
+	defer conn.Close()
+	dataplaneClient := crossconnect.NewMonitorCrossConnectClient(conn)
+
+	// Looping indefinetly or until grpc returns an error indicating the other end closed connection.
+	stream, err := dataplaneClient.MonitorCrossConnects(context.Background(), &empty.Empty{})
+
+	if err != nil {
+		logrus.Warningf("Error: %+v.", err)
+		return
+	}
+	t := proto.TextMarshaler{}
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			logrus.Errorf("Error: %+v.", err)
+			return
+		}
+		data := ""
+		println("\u001b[0m\n")
+		for _, cc := range event.CrossConnects {
+
+			data += fmt.Sprintf("\u001b[31m*** %s %s Id:%s \n\u001b[32m%s\n\u001b[0m", address, event.Type, cc.Id, t.Text(cc))
+		}
+		println(data)
+		if !continuousMonitor {
+			logrus.Infof("Monitoring of server: %s. is complete...", address)
+			delete(managers, address)
+			return
+		}
+	}
+}
+
+func lookForNSMServers() {
+	_, ok := os.LookupEnv("NODE_NAME")
+	if !ok {
+		logrus.Fatalf("You must set env variable NODE_NAME to match the name of your Node.  See https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/")
+	}
+	var kubeconfig *string
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+
+	// check if CRD is installed
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		logrus.Println("Unable to get in cluster config, attempting to fall back to kubeconfig", err)
+		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+		if err != nil {
+			logrus.Fatalln("Unable to build config", err)
+		}
+	}
+
+	// Initialize clientset
+	nsmClientSet, err := versioned.NewForConfig(config)
+	if err != nil {
+		logrus.Fatalln("Unable to initialize nsmd-k8s", err)
+	}
+
+	for !closing {
+		result, err := nsmClientSet.Networkservicemesh().NetworkServiceManagers("default").List(metav1.ListOptions{})
+		if err != nil {
+			logrus.Fatalln("Unable to find NSMs", err)
+		}
+		for _, mgr := range result.Items {
+			if _, ok := managers[mgr.Status.URL]; !ok {
+				logrus.Printf("Found manager: %s at %s", mgr.Name, mgr.Status.URL)
+				managers[mgr.Status.URL] = "true"
+				go monitorCrossConnects(mgr.Status.URL, true)
+			}
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func main() {
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		closing = true
+		wg.Done()
+	}()
+
+	lookForNSMServers()
+
+	wg.Wait()
+
+}

--- a/k8s/conf/crossconnect-monitor.yaml
+++ b/k8s/conf/crossconnect-monitor.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+spec:
+  template:
+    metadata:
+      labels:
+        app: nsmd-ds
+    spec:
+      containers:
+        - name: crossconnect-monitor
+          image: networkservicemesh/crossconnect-monitor:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/device-plugins
+            type: DirectoryOrCreate
+          name: kubelet-socket
+metadata:
+  name: crossconnect-monitor
+  namespace: default

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -37,6 +37,12 @@ if [ "$1" = "vppagent-dataplane" ]; then
     output=/bin/$1
 fi
 
+if [ "$1" = "crossconnect-monitor" ]; then
+    go_file=./k8s/cmd/crossconnect_monitor
+    port=40004
+    output=/bin/$1
+fi
+
 
 # Debug entry point
 mkdir -p ./bin

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -38,6 +38,10 @@ function run_tests() {
     yq w -i /tmp/vppagent-dataplane.yaml spec.template.spec.containers[0].image networkservicemesh/vppagent-dataplane:"${COMMIT}"
     kubectl apply -f /tmp/vppagent-dataplane.yaml
 
+    cp k8s/conf/crossconnect-monitor.yaml /tmp/crossconnect-monitor.yaml
+    yq w -i /tmp/crossconnect-monitor.yaml spec.template.spec.containers[0].image networkservicemesh/crossconnect-monitor:"${COMMIT}"
+    kubectl apply -f /tmp/crossconnect-monitor.yaml
+
     cp k8s/conf/nsmd.yaml /tmp/nsmd.yaml
     yq w -i /tmp/nsmd.yaml spec.template.spec.containers[0].image networkservicemesh/nsmdp:"${COMMIT}"
     yq w -i /tmp/nsmd.yaml spec.template.spec.containers[1].image networkservicemesh/nsmd:"${COMMIT}"


### PR DESCRIPTION
1. crossconnect-monitor is packaged as pod, listening for K8s NSM registered and starting looking for cross-connect events happening.
2. packaged as pod and deployed to test configuration.
3. make k8s-crossconnect-monitor-logs could be used to take logs.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>