### PR TITLE
A bit of streamlining Cross Connect Monitor

### DIFF
--- a/.k8s.mk
+++ b/.k8s.mk
@@ -141,6 +141,14 @@ k8s-vppagent-nsc-build:  ${CONTAINER_BUILD_PREFIX}-vppagent-nsc-build
 .PHONY: k8s-vppagent-nsc-save
 k8s-vppagent-nsc-save:  ${CONTAINER_BUILD_PREFIX}-vppagent-nsc-save
 
+
+.PHONY: k8s-crossconnect-monitor-build
+k8s-crossconnect-monitor-build: ${CONTAINER_BUILD_PREFIX}-crossconnect-monitor-build
+
+.PHONY: k8s-crossconnect-monitor-save
+k8s-crossconnect-monitor-save: ${CONTAINER_BUILD_PREFIX}-crossconnect-monitor-save
+
+
 # TODO add k8s-%-logs and k8s-logs to capture all the logs from k8s
 
 .PHONY: k8s-logs

--- a/k8s/cmd/crossconnect-monitor/crossconnect_monitor.go
+++ b/k8s/cmd/crossconnect-monitor/crossconnect_monitor.go
@@ -4,6 +4,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/crossconnect"
@@ -14,12 +21,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	"os"
-	"os/signal"
-	"path/filepath"
-	"sync"
-	"syscall"
-	"time"
 )
 
 var closing = false
@@ -66,10 +67,6 @@ func monitorCrossConnects(address string, continuousMonitor bool) {
 }
 
 func lookForNSMServers() {
-	_, ok := os.LookupEnv("NODE_NAME")
-	if !ok {
-		logrus.Fatalf("You must set env variable NODE_NAME to match the name of your Node.  See https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/")
-	}
 	var kubeconfig *string
 	if home := homedir.HomeDir(); home != "" {
 		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")

--- a/k8s/conf/crossconnect-monitor.yaml
+++ b/k8s/conf/crossconnect-monitor.yaml
@@ -11,16 +11,6 @@ spec:
         - name: crossconnect-monitor
           image: networkservicemesh/crossconnect-monitor:latest
           imagePullPolicy: IfNotPresent
-          env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-      volumes:
-        - hostPath:
-            path: /var/lib/kubelet/device-plugins
-            type: DirectoryOrCreate
-          name: kubelet-socket
 metadata:
   name: crossconnect-monitor
   namespace: default


### PR DESCRIPTION
The Cross Connect Monitor didn't really need the Node Name
and downward API pieces.  Also fixed some missing k8s-%-save rules
for it.