### PR TITLE
Make IP address pools configurable via Env variable

### DIFF
--- a/examples/cmd/icmp-responder-nse/nse.go
+++ b/examples/cmd/icmp-responder-nse/nse.go
@@ -22,11 +22,9 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/ligato/networkservicemesh/controlplane/pkg/nsmd"
-
 	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/local/networkservice"
 	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/registry"
-
+	"github.com/ligato/networkservicemesh/controlplane/pkg/nsmd"
 	"github.com/ligato/networkservicemesh/pkg/tools"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -35,7 +33,8 @@ import (
 const (
 	// networkServiceName defines Network Service Name the NSE is serving for
 	networkServiceName = "icmp-responder"
-	// SocketBaseDir defines the location of NSM Endpoints listen socket
+	// starting IP address for address pool
+	ipAddressEnv = "IP_ADDRESS"
 )
 
 func main() {
@@ -70,7 +69,9 @@ func main() {
 
 	// Registering NSE API, it will listen for Connection requests from NSM and return information
 	// needed for NSE's dataplane programming.
-	nseConn := New()
+	ipAddress, _ := os.LookupEnv(ipAddressEnv)
+	logrus.Infof("starting IP address: %s", ipAddress)
+	nseConn := New(ipAddress)
 
 	networkservice.RegisterNetworkServiceServer(grpcServer, nseConn)
 

--- a/examples/cmd/icmp-responder-nse/service.go
+++ b/examples/cmd/icmp-responder-nse/service.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
+	"net"
 	"sync"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -55,11 +57,22 @@ func (ns *networkService) Close(_ context.Context, conn *connection.Connection) 
 	return &empty.Empty{}, nil
 }
 
-func New() networkservice.NetworkServiceServer {
+func ip2int(ip net.IP) uint32 {
+	if ip == nil {
+		return 0
+	}
+	if len(ip) == 16 {
+		return binary.BigEndian.Uint32(ip[12:16])
+	}
+	return binary.BigEndian.Uint32(ip)
+}
+
+func New(ip string) networkservice.NetworkServiceServer {
 	monitor := monitor_connection_server.NewMonitorConnectionServer()
+	netIP := net.ParseIP(ip)
 	service := networkService{
 		networkService:          "icmp-responder",
-		nextIP:                  169083137, // 10.20.1.1
+		nextIP:                  ip2int(netIP), // 10.20.1.1
 		monitorConnectionServer: monitor,
 	}
 	return &service

--- a/examples/cmd/vppagent-icmp-responder-nse/nse.go
+++ b/examples/cmd/vppagent-icmp-responder-nse/nse.go
@@ -21,11 +21,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/ligato/networkservicemesh/controlplane/pkg/nsmd"
-
 	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/local/networkservice"
 	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/registry"
-
+	"github.com/ligato/networkservicemesh/controlplane/pkg/nsmd"
 	"github.com/ligato/networkservicemesh/pkg/tools"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -35,6 +33,7 @@ const (
 	// networkServiceName defines Network Service Name the NSE is serving for
 	NetworkServiceName      = "icmp-responder"
 	DefaultVPPAgentEndpoint = "localhost:9112"
+	ipAddressEnv            = "IP_ADDRESS"
 )
 
 func main() {
@@ -78,7 +77,9 @@ func main() {
 
 	// Registering NSE API, it will listen for Connection requests from NSM and return information
 	// needed for NSE's dataplane programming.
-	nseConn := New(DefaultVPPAgentEndpoint, workspace)
+	ipAddress, _ := os.LookupEnv(ipAddressEnv)
+	logrus.Infof("starting IP address: %s", ipAddress)
+	nseConn := New(DefaultVPPAgentEndpoint, workspace, ipAddress)
 
 	networkservice.RegisterNetworkServiceServer(grpcServer, nseConn)
 

--- a/k8s/conf/icmp-responder-nse.yaml
+++ b/k8s/conf/icmp-responder-nse.yaml
@@ -27,6 +27,9 @@ spec:
         - name: icmp-responder-nse
           image: networkservicemesh/icmp-responder-nse:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: IP_ADDRESS
+              value: "10.20.1.1"
           resources:
             limits:
               nsm.ligato.io/socket: 1

--- a/k8s/conf/vppagent-icmp-responder-nse.yaml
+++ b/k8s/conf/vppagent-icmp-responder-nse.yaml
@@ -29,6 +29,9 @@ spec:
             privileged: true
           image: networkservicemesh/vppagent-icmp-responder-nse:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: IP_ADDRESS
+              value: "10.30.1.1"
           resources:
             limits:
               nsm.ligato.io/socket: 1


### PR DESCRIPTION
Implements #556 - Make IP address pools for icmp-responder-nse and vppagent-icmp-responser-nse configurable via Env variable