### PR TITLE
Fix RemoteConnection

### DIFF
--- a/controlplane/pkg/nsmd/network_service_server.go
+++ b/controlplane/pkg/nsmd/network_service_server.go
@@ -267,14 +267,6 @@ func (srv *networkServiceServer) performRemoteNSERequest(ctx context.Context, re
 		return nil, err
 	}
 
-	if nseConnection.GetMechanism().Type == remote_connection.MechanismType_VXLAN {
-		// We need to switch directions of src<->dst
-		m := nseConnection.GetMechanism()
-		remoteDst := m.Parameters[remote_connection.VXLANDstIP]
-		nseConnection.GetMechanism().Parameters[remote_connection.VXLANDstIP] = m.Parameters[remote_connection.VXLANSrcIP]
-		nseConnection.GetMechanism().Parameters[remote_connection.VXLANSrcIP] = remoteDst
-		nseConnection.GetMechanism().Parameters[remote_connection.VXLANVNI] = srv.model.Vni()
-	}
 	dpApiConnection := &crossconnect.CrossConnect{
 		Id:      request.GetConnection().GetId(),
 		Payload: endpoint.GetNetworkService().GetPayload(),

--- a/controlplane/pkg/remote/network_service_server/remote_network_service_server.go
+++ b/controlplane/pkg/remote/network_service_server/remote_network_service_server.go
@@ -114,8 +114,8 @@ func (srv *remoteNetworkServiceServer) selectMechanism(request *remote_networkse
 		if mechanism.Type == remote_connection.MechanismType_VXLAN {
 			// Update DST IP to be ours
 			remoteSrc := mechanism.Parameters[remote_connection.VXLANSrcIP]
-			mechanism.Parameters[remote_connection.VXLANSrcIP] = dp_mechanism.Parameters[remote_connection.VXLANSrcIP]
-			mechanism.Parameters[remote_connection.VXLANDstIP] = remoteSrc
+			mechanism.Parameters[remote_connection.VXLANSrcIP] = remoteSrc
+			mechanism.Parameters[remote_connection.VXLANDstIP] = dp_mechanism.Parameters[remote_connection.VXLANSrcIP]
 			mechanism.Parameters[remote_connection.VXLANVNI] = srv.model.Vni()
 		}
 		return mechanism, nil

--- a/dataplane/vppagent/pkg/converter/cross_connect_converter.go
+++ b/dataplane/vppagent/pkg/converter/cross_connect_converter.go
@@ -47,7 +47,7 @@ func (c *CrossConnectConverter) ToDataRequest(rv *rpc.DataRequest) (*rpc.DataReq
 	}
 
 	if c.GetRemoteSource() != nil {
-		rv, err := NewRemoteConnectionConverter(c.GetRemoteSource(), "SRC-"+c.GetId()).ToDataRequest(rv)
+		rv, err := NewRemoteConnectionConverter(c.GetRemoteSource(), "SRC-"+c.GetId(), SOURCE).ToDataRequest(rv)
 		if err != nil {
 			return rv, fmt.Errorf("Error Converting CrossConnect %v: %s", c, err)
 		}
@@ -68,7 +68,7 @@ func (c *CrossConnectConverter) ToDataRequest(rv *rpc.DataRequest) (*rpc.DataReq
 	}
 
 	if c.GetRemoteDestination() != nil {
-		rv, err := NewRemoteConnectionConverter(c.GetRemoteDestination(), "DST-"+c.GetId()).ToDataRequest(rv)
+		rv, err := NewRemoteConnectionConverter(c.GetRemoteDestination(), "DST-"+c.GetId(), DESTINATION).ToDataRequest(rv)
 		if err != nil {
 			return rv, fmt.Errorf("Error Converting CrossConnect %v: %s", c, err)
 		}


### PR DESCRIPTION
With two CrossConnects that are 'connected' it must be true that:

CrossConnect1.GetRemoteDestination() == CrossConnect2.GetRemoteSource()

Because of this, the fliping of src/dst IPs for the tunnels needs to
happen in the converters in the vppagent-dataplane, not in the remote
NSE.