### PR TITLE
Allow using libvirt with vagrant

### DIFF
--- a/.k8s.mk
+++ b/.k8s.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-K8S_CONF_DIR = k8s/conf/
+K8S_CONF_DIR = k8s/conf
 
 # Need nsmdp and icmp-responder-nse here as well, but missing yaml files
 DEPLOY_NSM = nsmd vppagent-dataplane

--- a/.vagrant.mk
+++ b/.vagrant.mk
@@ -14,7 +14,7 @@
 
 .PHONY: vagrant-start
 vagrant-start:
-	@cd scripts/vagrant; vagrant up
+	@cd scripts/vagrant; vagrant up --no-parallel; source env.sh
 
 .PHONY: vagrant-destroy
 vagrant-destroy:
@@ -22,7 +22,7 @@ vagrant-destroy:
 
 .PHONY: vagrant-restart
 vagrant-restart: vagrant-destroy
-	@cd scripts/vagrant; sleep 2;vagrant up
+	@cd scripts/vagrant; sleep 2;vagrant up --no-parallel
 
 .PHONY: vagrant-suspend
 vagrant-suspend:

--- a/.vagrant.mk
+++ b/.vagrant.mk
@@ -14,7 +14,7 @@
 
 .PHONY: vagrant-start
 vagrant-start:
-	@cd scripts/vagrant; vagrant up --no-parallel; source env.sh
+	@cd scripts/vagrant; vagrant up --no-parallel;
 
 .PHONY: vagrant-destroy
 vagrant-destroy:

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -2,6 +2,12 @@
 
 This Vagrant directory provides a simple environment in which to test various components of Network Service Mesh.
 
+# Prerequisites
+
+Sshfs is used to mount the /vagrant directory of the guest. Hence the vagrant-sshfs plugin for vagrant must be installed.
+If libvirt is used, the vagrant-libvirt plugin must also be installed.
+
+
 # Starting Vagrant
 
 ```bash

--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -3,8 +3,13 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.synced_folder "../..", "/go/src/github.com/ligato/networkservicemesh"
+  config.vm.synced_folder "../..", "/go/src/github.com/ligato/networkservicemesh", type: "sshfs"
+  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
 
+  config.vm.provider "libvirt" do |v|
+        v.memory = 4096
+        v.cpus = 2
+  end
   config.vm.provider "virtualbox" do |v|
         v.memory = 4096
         v.cpus = 2
@@ -17,7 +22,7 @@ Vagrant.configure("2") do |config|
     v.vmx["memsize"] = "4096"
     v.vmx["numvcpus"] = "2"
   end
-  config.vm.box = "bento/ubuntu-18.04"
+  config.vm.box = "generic/debian9"
   config.vm.network "private_network", type: "dhcp"
 
   config.vm.provision "shell", inline: <<-EOC

--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -3,8 +3,9 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.synced_folder "../..", "/go/src/github.com/ligato/networkservicemesh", type: "sshfs"
-  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
+  config.vm.synced_folder "../..", "/go/src/github.com/ligato/networkservicemesh"
+  config.vm.synced_folder ".", "/vagrant"
+  config.vm.allowed_synced_folder_types = [:virtualbox, :sshfs]
 
   config.vm.provider "libvirt" do |v|
         v.memory = 4096

--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -7,23 +7,26 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant"
   config.vm.allowed_synced_folder_types = [:virtualbox, :vmware, :sshfs]
 
-  config.vm.provider "libvirt" do |v|
-        v.memory = 4096
-        v.cpus = 2
+  config.vm.provider "libvirt" do |v, override|
+    override.vm.box = "generic/ubuntu1604"
+    v.memory = 4096
+    v.cpus = 2
   end
-  config.vm.provider "virtualbox" do |v|
-        v.memory = 4096
-        v.cpus = 2
+  config.vm.provider "virtualbox" do |v, override|
+    override.vm.box = "bento/ubuntu-18.04"
+    v.memory = 4096
+    v.cpus = 2
   end
-  config.vm.provider "vmware_desktop" do |v|
+  config.vm.provider "vmware_desktop" do |v, override|
+    override.vm.box = "bento/ubuntu-18.04"
     v.vmx["memsize"] = "4096"
     v.vmx["numvcpus"] = "2"
   end
-  config.vm.provider "vmware_fusion" do |v|
+  config.vm.provider "vmware_fusion" do |v, override|
+    override.vm.box = "bento/ubuntu-18.04"
     v.vmx["memsize"] = "4096"
     v.vmx["numvcpus"] = "2"
   end
-  config.vm.box = "generic/ubuntu1604"
   config.vm.network "private_network", type: "dhcp"
 
   config.vm.provision "shell", inline: <<-EOC

--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.synced_folder "../..", "/go/src/github.com/ligato/networkservicemesh"
   config.vm.synced_folder ".", "/vagrant"
-  config.vm.allowed_synced_folder_types = [:virtualbox, :sshfs]
+  config.vm.allowed_synced_folder_types = [:virtualbox, :sshfs, :vmware]
 
   config.vm.provider "libvirt" do |v|
         v.memory = 4096
@@ -23,7 +23,7 @@ Vagrant.configure("2") do |config|
     v.vmx["memsize"] = "4096"
     v.vmx["numvcpus"] = "2"
   end
-  config.vm.box = "generic/debian9"
+  config.vm.box = "generic/ubuntu1604"
   config.vm.network "private_network", type: "dhcp"
 
   config.vm.provision "shell", inline: <<-EOC

--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.synced_folder "../..", "/go/src/github.com/ligato/networkservicemesh"
   config.vm.synced_folder ".", "/vagrant"
-  config.vm.allowed_synced_folder_types = [:virtualbox, :sshfs, :vmware]
+  config.vm.allowed_synced_folder_types = [:virtualbox, :vmware, :sshfs]
 
   config.vm.provider "libvirt" do |v|
         v.memory = 4096


### PR DESCRIPTION
Use sshfs for mounting /vagrant directory.
Use generic/debian9 box that is compatible with libvirt
and generic/ubuntu1804 has resolver issues.

Signed-off-by: Mathieu Rohon <mathieu.rohon@orange.com>