### PR TITLE
docs: split QUICK-START.md for different OS

### DIFF
--- a/Ubuntu.md
+++ b/Ubuntu.md
@@ -1,0 +1,45 @@
+
+Installing the prerequisites:
+
+Latest Vagrant repo:
+
+sudo bash -c 'echo deb https://vagrant-deb.linestarve.com/ any main > /etc/apt/sources.list.d/wolfgang42-vagrant.list'
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
+
+Latest Kubernetes reporsitory:
+
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add
+sudo apt-add-repository "deb http://apt.kubernetes.io/ kubernetes-xenial main"
+
+
+sudo apt update
+
+VirtualBox, Vagrant, Docker and kubectl
+
+sudo apt install -y virtualbox vagrant docker.io kubectl
+sudo systemctl enable docker
+sudo usermod -aG docker $USER
+# log out / log in
+Logout to get the user into the `docker` usergroup.
+
+Get the Network Service Mesh repo:
+git clone https://github.com/ligato/networkservicemesh
+cd networkservicemesh
+
+Build the virtual machines with Docker and Kubernetes installed:
+make vagrant-start
+
+This a very important step, redirect `kubectl` to point to the just installed Kubernetes cluster in the Vagrant master virtual machine:
+source scripts/vagrant/env.sh
+
+Now verify the setup by checking the nodes status
+kubectl get nodes
+
+make k8s-save
+
+make k8s-infra-deploy
+
+make k8s-icmp-deploy
+
+make k8s-check
+

--- a/docs/CentOS.md
+++ b/docs/CentOS.md
@@ -1,18 +1,18 @@
-# Preapring an Ubuntu host to run Network Service Mesh
+# Preparing an Ubuntu host to run Network Service Mesh
 
-The following instructions assume CentOS 7 installed with Gnomde Desktop.
+The following instructions assume CentOS 7 installed with Gnome Desktop.
 
 
 ## VirtualBox
 
-VirtualBox depends on a kernel module wild with DKMS, so in order to install it you'll need to prepare by adding some dependecies.
+VirtualBox depends on a kernel module wild with DKMS, so in order to install it you'll need to prepare by adding some dependencies.
 
 ```bash
 sudo yum -y install gcc dkms make qt libgomp patch
 sudo yum -y install kernel-headers kernel-devel binutils glibc-headers glibc-devel font-forge
 ```
 
-Add the VirtualBox repo and get the latest released version fo the package.
+Add the VirtualBox repo and get the latest released version of the package.
 
 ```bash
 sudo wget http://download.virtualbox.org/virtualbox/rpm/rhel/virtualbox.repo -P /etc/yum.repos.d/
@@ -29,7 +29,7 @@ sudo yum install -y https://releases.hashicorp.com/vagrant/2.2.2/vagrant_2.2.2_x
 
 ## Docker
 
-Docker maintain a repo for CentOS, so the installation is straightfoward.
+Docker maintain a repo for CentOS, so the installation is straightforward.
 
 ```bash
 sudo yum install -y yum-utils device-mapper-persistent-data lvm2
@@ -68,7 +68,7 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
 EOF
 ```
 
-Then install only the `kubectl` pakcage:
+Then install only the `kubectl` package:
 
 ```bash
 sudo yum install -y kubectl

--- a/docs/CentOS.md
+++ b/docs/CentOS.md
@@ -1,0 +1,83 @@
+# Preapring an Ubuntu host to run Network Service Mesh
+
+The following instructions assume CentOS 7 installed with Gnomde Desktop.
+
+
+## VirtualBox
+
+VirtualBox depends on a kernel module wild with DKMS, so in order to install it you'll need to prepare by adding some dependecies.
+
+```bash
+sudo yum -y install gcc dkms make qt libgomp patch
+sudo yum -y install kernel-headers kernel-devel binutils glibc-headers glibc-devel font-forge
+```
+
+Add the VirtualBox repo and get the latest released version fo the package.
+
+```bash
+sudo wget http://download.virtualbox.org/virtualbox/rpm/rhel/virtualbox.repo -P /etc/yum.repos.d/
+sudo yum -y install VirtualBox-6.0
+```
+
+## Vagrant
+
+The last version fo vagrant can be installed straight from their site:
+
+```bash
+sudo yum install -y https://releases.hashicorp.com/vagrant/2.2.2/vagrant_2.2.2_x86_64.rpm
+```
+
+## Docker
+
+Docker maintain a repo for CentOS, so the installation is straightfoward.
+
+```bash
+sudo yum install -y yum-utils device-mapper-persistent-data lvm2
+sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum install -y docker-ce
+sudo systemctl enable docker.service
+sudo systemctl start docker.service
+```
+
+You need to be in the `docker` group so you can run the commands as user.
+
+```bash
+sudo usermod -aG docker $(whoami)
+```
+
+Log out and log back in to get into the Docker usergroup. Verify docker is operational.
+
+```bash
+$ docker ps
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+```
+
+## Kubectl
+
+Become root and add the Kubernetes repo:
+
+```bash
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+```
+
+Then install only the `kubectl` pakcage:
+
+```bash
+sudo yum install -y kubectl
+```
+
+## dev tools
+
+To be able to deploy Network Service Mesh you will need a couple of tools which are part of the Development Tools package group. Install it.
+
+```bash
+sudo yum groups install "Development Tools"
+```

--- a/docs/OSX.md
+++ b/docs/OSX.md
@@ -1,0 +1,12 @@
+# Preapring an OSX host to run Network Service Mesh
+
+
+[Docker desktop](https://www.docker.com/products/docker-desktop) installed from the official packages
+
+Please ensure that Docker is started, or optionally select "Start Docker Desktop when you login" on the General tab in Docker's Preferences.
+
+The rest of the pre-requistes can be easily installed with `brew`.
+
+```bash
+brew install kubectl && brew cask install virtualbox vagrant
+```

--- a/docs/OSX.md
+++ b/docs/OSX.md
@@ -1,11 +1,11 @@
-# Preapring an OSX host to run Network Service Mesh
+# Preparing an OSX host to run Network Service Mesh
 
 
 [Docker desktop](https://www.docker.com/products/docker-desktop) installed from the official packages
 
-Please ensure that Docker is started, or optionally select "Start Docker Desktop when you login" on the General tab in Docker's Preferences.
+Please ensure that Docker is started, or optionally select "Start Docker Desktop when you log in" on the General tab in Docker's Preferences.
 
-The rest of the pre-requistes can be easily installed with `brew`.
+The rest of the pre-requisites can be easily installed with `brew`.
 
 ```bash
 brew install kubectl && brew cask install virtualbox vagrant

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -9,7 +9,7 @@ You can find instructions for your operation systems in the links below:
 * [OSX](OSX.md)
 * [Ubuntu](Ubuntu.md)
 
-If you have another Linux distrinbution or prefer to go with the upstream, here 
+If you have another Linux distribution or prefer to go with the upstream, here 
 
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 * [Vagrant](https://www.vagrantup.com/docs/installation/)

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -1,53 +1,20 @@
 # Quick Start Network Service Mesh
 
-This document will configure two Vagrant boxes in a Kubernetes cluster with a master and a worker node. It will also deploy the Network Service Mesh components in the cluster.
+This document will help you configure two Vagrant boxes in a Kubernetes cluster with a master and a worker node. You will also deploy the Network Service Mesh components in the cluster.
 
-The following instructions assume Ubuntu 18.04.
+## Pre-requisites
 
-### Ubuntu pre-requisites installation
+You can find instructions for your operation systems in the links below:
+* [CentOS](CentOS.md)
+* [OSX](OSX.md)
+* [Ubuntu](Ubuntu.md)
 
-To get the latest Vagrant verision we propose adding the following repo:
-
-```bash
-sudo bash -c 'echo deb https://vagrant-deb.linestarve.com/ any main > /etc/apt/sources.list.d/wolfgang42-vagrant.list'
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
-```
-
-The latest `kubectl` is available with this repo:
-
-```bash
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add
-sudo apt-add-repository "deb http://apt.kubernetes.io/ kubernetes-xenial main"
-```
-
-After adding these repos, one needs to update and install the required packages as follows:
-
-```bash
-sudo apt update
-sudo apt install -y virtualbox vagrant docker.io kubectl
-```
-
-The Docker service needs to be enabled:
-
-```bash
-sudo systemctl enable docker
-```
-
-And then the current user should be added to the proper user group:
-
-```bash
-sudo usermod -aG docker $USER
-```
-
-Log out and log in again, so that the user group addition takes effect.
-
-### Generic pre-requisites installation instructions
-
-If you are not using Ubuntu, you can try following the generic installation instructions from here:
+If you have another Linux distrinbution or prefer to go with the upstream, here 
 
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 * [Vagrant](https://www.vagrantup.com/docs/installation/)
 * [Docker](https://docs.docker.com/install/)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
 ### Getting the Network Service Mesh project
 

--- a/docs/Ubuntu.md
+++ b/docs/Ubuntu.md
@@ -1,0 +1,44 @@
+# Preapring an Ubuntu host to run Network Service Mesh
+
+The following instructions assume Ubuntu 18.04.
+
+## Vagrant
+
+Please add the following repo to ensure getting the latest Vagrant:
+
+```bash
+sudo bash -c 'echo deb https://vagrant-deb.linestarve.com/ any main > /etc/apt/sources.list.d/wolfgang42-vagrant.list'
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
+```
+
+## Kubectl
+
+Although `kubectl` can be donwloaded as a snap, we recommend usint the official Kubernetes repo:
+
+```bash
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add
+sudo apt-add-repository "deb http://apt.kubernetes.io/ kubernetes-xenial main"
+```
+
+## Install everything needed
+
+After adding these repos, one needs to update and install the required packages as follows:
+
+```bash
+sudo apt update
+sudo apt install -y virtualbox vagrant docker.io kubectl
+```
+
+The Docker service needs to be enabled:
+
+```bash
+sudo systemctl enable docker
+```
+
+And then the current user should be added to the proper user group:
+
+```bash
+sudo usermod -aG docker $USER
+```
+
+Log out and log in again, so that the user group addition takes effect.

--- a/docs/Ubuntu.md
+++ b/docs/Ubuntu.md
@@ -1,4 +1,4 @@
-# Preapring an Ubuntu host to run Network Service Mesh
+# Preparing an Ubuntu host to run Network Service Mesh
 
 The following instructions assume Ubuntu 18.04.
 
@@ -13,7 +13,7 @@ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key AD319E0F7C
 
 ## Kubectl
 
-Although `kubectl` can be donwloaded as a snap, we recommend usint the official Kubernetes repo:
+Although `kubectl` can be downloaded as a snap, we recommend using the official Kubernetes repo:
 
 ```bash
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add


### PR DESCRIPTION
Add separate instructions for CentOS, OSX and Ubuntu.

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>