### PR TITLE
Makefile: don't make noise when go is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ include .k8s.mk
 include .skydive.mk
 include .monitor.mk
 
-GOPATH?=$(shell go env GOPATH)
+GOPATH?=$(shell go env GOPATH 2>/dev/null)
 GOCMD=go
 GOFMT=${GOCMD} fmt
 GOGET=${GOCMD} get


### PR DESCRIPTION
We really need 'go' on the host mostly for checks nad CI/CD.
All the images are generated in Docker. There is no real need to
be noisy about the lack of go.

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>