### PR TITLE
Use #572 extra prefixes for ICMP responder NSE

### DIFF
--- a/examples/cmd/icmp-responder-nse/nse.go
+++ b/examples/cmd/icmp-responder-nse/nse.go
@@ -78,7 +78,7 @@ func main() {
 	// Registering NSE API, it will listen for Connection requests from NSM and return information
 	// needed for NSE's dataplane programming.
 	ipAddress, _ := os.LookupEnv(ipAddressEnv)
-	logrus.Infof("starting IP address: %s", ipAddress)
+	logrus.Infof("IP Network address: %s", ipAddress)
 	nseConn := New(ipAddress)
 
 	networkservice.RegisterNetworkServiceServer(grpcServer, nseConn)

--- a/examples/cmd/icmp-responder-nse/service.go
+++ b/examples/cmd/icmp-responder-nse/service.go
@@ -16,8 +16,7 @@ package main
 
 import (
 	"context"
-	"encoding/binary"
-	"net"
+	"github.com/ligato/networkservicemesh/controlplane/pkg/prefix_pool"
 	"sync"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -30,7 +29,7 @@ import (
 type networkService struct {
 	sync.RWMutex
 	networkService          string
-	nextIP                  uint32
+	prefixPool              prefix_pool.PrefixPool
 	monitorConnectionServer monitor_connection_server.MonitorConnectionServer
 }
 
@@ -47,32 +46,25 @@ func (ns *networkService) Request(ctx context.Context, request *networkservice.N
 		return nil, err
 	}
 	ns.monitorConnectionServer.UpdateConnection(conn)
-
 	return conn, nil
 }
 
 func (ns *networkService) Close(_ context.Context, conn *connection.Connection) (*empty.Empty, error) {
 	// remove from connection
 	ns.monitorConnectionServer.DeleteConnection(conn)
-	return &empty.Empty{}, nil
-}
-
-func ip2int(ip net.IP) uint32 {
-	if ip == nil {
-		return 0
-	}
-	if len(ip) == 16 {
-		return binary.BigEndian.Uint32(ip[12:16])
-	}
-	return binary.BigEndian.Uint32(ip)
+	err := ns.prefixPool.Release(conn.Id)
+	return &empty.Empty{}, err
 }
 
 func New(ip string) networkservice.NetworkServiceServer {
 	monitor := monitor_connection_server.NewMonitorConnectionServer()
-	netIP := net.ParseIP(ip)
+	pool, err := prefix_pool.NewPrefixPool(ip)
+	if err != nil {
+		panic(err.Error())
+	}
 	service := networkService{
 		networkService:          "icmp-responder",
-		nextIP:                  ip2int(netIP), // 10.20.1.1
+		prefixPool:              pool, // 10.20.1.1
 		monitorConnectionServer: monitor,
 	}
 	return &service

--- a/k8s/conf/icmp-responder-nse.yaml
+++ b/k8s/conf/icmp-responder-nse.yaml
@@ -31,7 +31,7 @@ spec:
             - name: NSE_LABELS
               value: "app=icmp-responder"
             - name: IP_ADDRESS
-              value: "10.20.1.1"
+              value: "10.20.1.0/24"
           resources:
             limits:
               nsm.ligato.io/socket: 1


### PR DESCRIPTION
Use #572 extra prefixes for ICMP responder NSE.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>