### PR TITLE
Revert "Use #572 extra prefixes for ICMP responder NSE (#645)"

### DIFF
--- a/examples/cmd/icmp-responder-nse/nse.go
+++ b/examples/cmd/icmp-responder-nse/nse.go
@@ -78,7 +78,7 @@ func main() {
 	// Registering NSE API, it will listen for Connection requests from NSM and return information
 	// needed for NSE's dataplane programming.
 	ipAddress, _ := os.LookupEnv(ipAddressEnv)
-	logrus.Infof("IP Network address: %s", ipAddress)
+	logrus.Infof("starting IP address: %s", ipAddress)
 	nseConn := New(ipAddress)
 
 	networkservice.RegisterNetworkServiceServer(grpcServer, nseConn)

--- a/k8s/conf/icmp-responder-nse.yaml
+++ b/k8s/conf/icmp-responder-nse.yaml
@@ -31,7 +31,7 @@ spec:
             - name: NSE_LABELS
               value: "app=icmp-responder"
             - name: IP_ADDRESS
-              value: "10.20.1.0/24"
+              value: "10.20.1.1"
           resources:
             limits:
               nsm.ligato.io/socket: 1


### PR DESCRIPTION
This reverts commit 6c42abcab9a3d35b54b4aa7dbaa8248960559ac4.

It was causing breakage in master.  Apparently by issuing /32s 
to pods without providing correct 'glue' to make that work.