### PR TITLE
Adds hostname to OpenTracing service name

### DIFF
--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -155,7 +155,16 @@ func InitJaeger(service string) (opentracing.Tracer, io.Closer) {
 			LocalAgentHostPort: jaegerHostPort,
 		},
 	}
-	tracer, closer, err := cfg.New(service, config.Logger(jaeger.StdLogger))
+
+	hostname, err := os.Hostname()
+	var serviceName string
+	if err == nil {
+		serviceName = fmt.Sprintf("%s@%s", service, hostname)
+	} else {
+		serviceName = service
+	}
+
+	tracer, closer, err := cfg.New(serviceName, config.Logger(jaeger.StdLogger))
 	if err != nil {
 		panic(fmt.Sprintf("ERROR: cannot init Jaeger: %v\n", err))
 	}


### PR DESCRIPTION
As suggested in #660 this PR adds hostname to a service name in OpenTracing support.