### PR TITLE
Issue #669: Fix bug with cross-connect monitor

### DIFF
--- a/controlplane/pkg/nsmd/network_service_server.go
+++ b/controlplane/pkg/nsmd/network_service_server.go
@@ -132,12 +132,13 @@ func (srv *networkServiceServer) Request(ctx context.Context, request *networkse
 
 	logrus.Infof("Sending request to dataplane: %v", clientConnection.Xcon)
 
+	srv.model.AddClientConnection(clientConnection)
 	clientConnection.Xcon, err = dataplaneClient.Request(ctx, clientConnection.Xcon)
 	if err != nil {
 		logrus.Errorf("Dataplane request failed: %s", err)
+		srv.model.DeleteClientConnection(clientConnection.ConnectionId)
 		return nil, err
 	}
-	srv.model.AddClientConnection(clientConnection)
 	// TODO - be more cautious here about bad return values from Dataplane
 	con := clientConnection.Xcon.GetSource().(*crossconnect.CrossConnect_LocalSource).LocalSource
 	srv.workspace.MonitorConnectionServer().UpdateConnection(con)

--- a/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
+++ b/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
@@ -159,7 +159,7 @@ func (client *NsmMonitorCrossConnectClient) dataplaneCrossConnectMonitor(datapla
 			logrus.Infof("Receive event from dataplane %s: %s %s", dataplane.RegisteredName, event.Type, event.CrossConnects)
 
 			for _, xcon := range event.GetCrossConnects() {
-				clientConnection := client.xconManager.GetClientConnectionByXcon(xcon.Id)
+				clientConnection := client.xconManager.GetClientConnectionByXcon(xcon)
 				if clientConnection == nil {
 					continue
 				}
@@ -172,6 +172,8 @@ func (client *NsmMonitorCrossConnectClient) dataplaneCrossConnectMonitor(datapla
 					if dst := xcon.GetLocalDestination(); dst != nil && dst.State == local_connection.State_DOWN {
 						client.xconManager.UpdateClientConnectionDstState(clientConnection, dst.State)
 					}
+					clientConnection.Xcon = xcon
+					client.xconManager.UpdateClientConnection(clientConnection)
 					client.crossConnectMonitor.UpdateCrossConnect(xcon)
 				case crossconnect.CrossConnectEventType_DELETE:
 					client.xconManager.DeleteClientConnection(clientConnection, false, false)

--- a/test/integration/death_handling_test.go
+++ b/test/integration/death_handling_test.go
@@ -157,7 +157,7 @@ func testDie(t *testing.T, killSrc bool, nodesCount int) {
 		}
 
 		k8s.DeletePods("default", podToKill)
-		time.Sleep(5 * time.Second)
+		time.Sleep(10 * time.Second)
 
 		ipResponse, errOut, err = k8s.Exec(podToCheck, podToCheck.Spec.Containers[0].Name, "ip", "addr")
 		Expect(err).To(BeNil())


### PR DESCRIPTION
Bug was related to synchronization in nsmd. Sometimes it received CrossConnectEvent from dataplane before CrossConnect was saved to Model and ignored it.

Fix: save ClientConnection to Model before Request to dataplane. Cross-connect for that ClientConnection will be set later, when appropriate event from dataplane will be received.

Signed-off-by: Ilya Lobkov <lobkovilya@yandex.ru>